### PR TITLE
Add help to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,28 @@
-test: unit-test integration-test
+##@ Test
 
-unit-test:
+test: unit-test integration-test ## Run all tests
+
+unit-test: ## Run the unit tests
 	go test -count=1 ./pkg/...
 
-integration-test:
+integration-test: ## Run the integration tests
 	go test -count=1 ./tests/...
 
-lint:
-	golangci-lint run
+##@ Build
 
-build:
+lint:
+	golangci-lint run ## Run the linter
+
+build: ## Build the pctl binary to ./pctl
 	go build -o pctl ./cmd/pctl
+
+##@ Utility
+
+.PHONY: help
+help:  ## Display this help. Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/
+ifeq ($(OS),Windows_NT)
+		@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make <target>\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-30s %s\n", $$1, $$2 } /^##@/ { printf "\n%s\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+else
+		@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+endif
+


### PR DESCRIPTION
### Description
Every civilised project has one

```
 $ pctl make help

Usage:
  make <target>

Test
  test                            Run all tests
  unit-test                       Run the unit tests
  integration-test                Run the integration tests

Build
  build                           Build the pctl binary to ./pctl

Utility
  help                            Display this help. Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/
```
