### PR TITLE
Fixing linting and adding a more strict linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+# .golangci.yml
+run:
+  skip-dirs:
+    - fakes
+linters-settings:
+  golint:
+    min-confidence: 0.9
+linters:
+  enable:
+    - golint
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ integration-test: ## Run the integration tests
 ##@ Build
 
 lint:
-	golangci-lint run ## Run the linter
+	golangci-lint run --exclude-use-default=false --timeout=5m0s ## Run the linter
 
 build: ## Build the pctl binary to ./pctl
 	go build -o pctl ./cmd/pctl

--- a/cmd/pctl/main.go
+++ b/cmd/pctl/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/urfave/cli/v2"
+
 	"github.com/weaveworks/pctl/pkg/catalog"
 )
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,5 +1,6 @@
 package catalog
 
+// ProfileDescription defines the descriptive properties of a profile.
 type ProfileDescription struct {
 	Name        string `yaml:"name,omitempty"`
 	Description string `yaml:"description,omitempty"`

--- a/pkg/catalog/search.go
+++ b/pkg/catalog/search.go
@@ -16,8 +16,7 @@ type HTTPClient interface {
 
 var httpClient HTTPClient = http.DefaultClient
 
-// Search will returns profiles for a given catalog by `catalogURL` which contain the give
-// name defined by `profileName`.
+// Search will return profile descriptions for a given `catalogURL` and `profileName`.
 func Search(catalogURL, profileName string) ([]ProfileDescription, error) {
 	u, err := url.Parse(catalogURL)
 	if err != nil {

--- a/pkg/catalog/search.go
+++ b/pkg/catalog/search.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 )
 
+// HTTPClient defines an http client which then can be used to test the
+// handler code.
 //go:generate counterfeiter -o fakes/fake_http_client.go . HTTPClient
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
@@ -14,6 +16,8 @@ type HTTPClient interface {
 
 var httpClient HTTPClient = http.DefaultClient
 
+// Search will returns profiles for a given catalog by `catalogURL` which contain the give
+// name defined by `profileName`.
 func Search(catalogURL, profileName string) ([]ProfileDescription, error) {
 	u, err := url.Parse(catalogURL)
 	if err != nil {
@@ -31,7 +35,11 @@ func Search(catalogURL, profileName string) ([]ProfileDescription, error) {
 	if err != nil {
 		return []ProfileDescription{}, fmt.Errorf("failed to fetch catalog: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Failed to close the response body from profile search with error: %v/n", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return []ProfileDescription{}, fmt.Errorf("failed to fetch catalog: status code %d", resp.StatusCode)

--- a/pkg/catalog/search.go
+++ b/pkg/catalog/search.go
@@ -16,7 +16,7 @@ type HTTPClient interface {
 
 var httpClient HTTPClient = http.DefaultClient
 
-// Search will return profile descriptions for a given `catalogURL` and `profileName`.
+// Search queries the catalog at catalogURL for profiles matching the provided profileName.
 func Search(catalogURL, profileName string) ([]ProfileDescription, error) {
 	u, err := url.Parse(catalogURL)
 	if err != nil {


### PR DESCRIPTION
### Description

This PR will fix the linter checker to be more precise and aggressive. But still allows some wiggle room as confidence of golinter is set to 1 which ignores things like, error shouldn't be a full sentence and kClient shouldn't start with a k.

### Checklist
- [x] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)

### Imports

Import statements now follow the following structure:

- stdlib
- thridparty
- organisational third party
- package local