### PR TITLE
Add --output flag to search and show commands

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -35,6 +35,6 @@ jobs:
         uses: fluxcd/flux2/action@main
       - name: Test
         run: |
-          PATH=$PATH:$(go env GOPATH)/bin make integration-test
+          PATH=$PATH:$(go env GOPATH)/bin make integration
     env:
       GIT_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -24,4 +24,4 @@ jobs:
           go get -u github.com/onsi/ginkgo/ginkgo
       - name: Test
         run: |
-          PATH=$PATH:$(go env GOPATH)/bin make unit-test
+          PATH=$PATH:$(go env GOPATH)/bin make unit

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 ##@ Test
 
-test: lint unit-test integration-test ## Run all tests
+test: lint unit integration ## Run all tests
 
-unit-test: ## Run the unit tests
+unit: ## Run the unit tests
 	ginkgo -r ./pkg
 
-integration-test: build local-env ## Run the integration tests
+integration: build local-env ## Run the integration tests
 	ginkgo -r ./tests/...
 
 local-env: submodule

--- a/README.md
+++ b/README.md
@@ -1,14 +1,47 @@
 # pctl
-pctl is a cli for interacting with [Profiles](https://github.com/weaveworks/profiles)
+pctl is a cli tool for interacting with [Profiles](https://github.com/weaveworks/profiles)
 
-## Commands
+<!--
+To update the TOC, install https://github.com/kubernetes-sigs/mdtoc
+and run: mdtoc -inplace README.md
+-->
+
+ <!-- toc -->
+- [Usage](#usage)
+  - [Search](#search)
+  - [Show](#show)
+  - [Install](#install)
+  - [Catalog service options](#catalog-service-options)
+- [Development](#development)
+  - [Tests](#tests)
+<!-- /toc -->
+
+## Usage
+
+For more information on all commands, run `pctl --help` or `pctl <subcommand> --help`.
 
 ### Search
 pctl can be used to search a catalog for profiles, example:
+```sh
+$ pctl search nginx
+CATALOG/PROFILE                         VERSION DESCRIPTION
+nginx-catalog-1/weaveworks-nginx        0.0.1   This installs nginx.
+nginx-catalog-1/some-other-nginx        1.0.1   This installs some other nginx.
 ```
-$ pctl search --catalog-url=$CATALOG_URL nginx
-searching for profiles matching "nginx":
-weaveworks-nginx: This installs nginx.
+
+### Show
+
+pctl can be used to get more information about a specific profile, example:
+
+```
+$ pctl show nginx-catalog-1/weaveworks-nginx
+Catalog         nginx-catalog-1
+Name            weaveworks-nginx
+Version         0.0.1
+Description     This installs nginx.
+URL             https://github.com/weaveworks/nginx-profile
+Maintainer      weaveworks (https://github.com/weaveworks/profiles)
+Prerequisites   Kubernetes 1.18+
 ```
 
 ### Install
@@ -16,15 +49,19 @@ weaveworks-nginx: This installs nginx.
 pctl can be used to install a profile subscription for a profile, example:
 
 ```
-pctl --catalog-url http://localhost:8000 install nginx-catalog/weaveworks-nginx
+pctl install nginx-catalog/weaveworks-nginx
 generating subscription for profile nginx-catalog/weaveworks-nginx:
 ```
 
 Then the result will be in profile-subscription.yaml file.
 
-## Local testing
+### Catalog service options
 
-In order to test the CLI you need a profiles catalog controller up and running along with its API.
+The catalog service options can be configured via `--catalog-service-name`, `--catalog-service-port` and `--catalog-service-namespace`
+
+## Development
+
+In order to run CLI commands you need a profiles catalog controller up and running along with its API in a cluster.
 To get a local setup clone the [Profiles repo](https://github.com/weaveworks/profiles) and run `make local-env`.
 This will deploy a local kind cluster with the catalog controller and API running. Once the environment is setup
 run the following to use pctl against it:
@@ -32,6 +69,13 @@ run the following to use pctl against it:
 1. Create your catalog, for example there is a `examples/profile-catalog-source.yaml` file in the profiles repo
 `kubectl apply -f profiles/examples/profile-catalog-source.yaml`
 1. Ensure the current context in kubeconfig is set to the `profiles` cluster (`kubectl config current-context` should return `kind-profiles`)
-1. Run `pctl search <query>` to search for your profile
-1. To see more details of a profile, run `pctl show <catalog-name>/<profile-name>`
-1. [Optional] The catalog service options can be configured via `--catalog-service-name`, `--catalog-service-port` and `--catalog-service-namespace`
+1. Create a `pctl` binary with `make build`.
+
+### Tests
+
+1. Run `make integration` for integration tests _(This will set up the required env, no need to do anything beforehand.
+   Note: if you have a `local-env` running and have created profile catalog sources in it, this will influence your tests.)_
+1. Run `make unit` for unit tests
+1. Run `make test` to run all tests
+
+See `make help` for all development commands.

--- a/cmd/pctl/main.go
+++ b/cmd/pctl/main.go
@@ -61,12 +61,19 @@ func searchCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+			outFormat := c.String("output")
+			if outFormat == "table" {
+				if len(profiles) == 0 {
+					fmt.Printf("No profiles found matching: '%s'\n", searchName)
+					return nil
+				}
+			}
 
 			var f formatter.Formatter
 			f = formatter.NewTableFormatter()
 			getter := searchDataFunc(profiles)
 
-			if c.String("output") == "json" {
+			if outFormat == "json" {
 				f = formatter.NewJSONFormatter()
 				getter = func() interface{} { return profiles }
 			}
@@ -139,7 +146,7 @@ func installCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "install",
 		Usage:     "generate a profile subscription for a profile in a catalog",
-		UsageText: "pctl --catalog-url <URL> install --subscription-name pctl-profile --namespace default --branch main --config-secret configmap-name --out profile_subscription.yaml <CATALOG>/<PROFILE>",
+		UsageText: "pctl [--kubeconfig-path=<kubeconfig-path>] install --subscription-name pctl-profile --namespace default --branch main --config-secret configmap-name --out profile_subscription.yaml <CATALOG>/<PROFILE>",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "subscription-name",

--- a/cmd/pctl/main.go
+++ b/cmd/pctl/main.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/weaveworks/pctl/pkg/catalog"
@@ -87,7 +86,16 @@ func showCmd() *cli.Command {
 	return &cli.Command{
 		Name:      "show",
 		Usage:     "display information about a profile",
-		UsageText: "pctl --kubeconfig=<kubeconfig-path> show <CATALOG>/<PROFILE>",
+		UsageText: "pctl [--kubeconfig=<kubeconfig-path>] show <CATALOG>/<PROFILE>",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "output",
+				Aliases:     []string{"o"},
+				DefaultText: "table",
+				Value:       "table",
+				Usage:       "Output format. json|table",
+			},
+		},
 		Action: func(c *cli.Context) error {
 			profilePath, catalogClient, err := parseArgs(c)
 			if err != nil {
@@ -102,12 +110,27 @@ func showCmd() *cli.Command {
 			}
 			catalogName, profileName := parts[0], parts[1]
 
-			fmt.Printf("retrieving information for profile %s/%s:\n\n", catalogName, profileName)
 			profile, err := catalog.Show(catalogClient, catalogName, profileName)
 			if err != nil {
 				return err
 			}
-			return printProfile(profile)
+
+			var f formatter.Formatter
+			f = formatter.NewTableFormatter()
+			getter := showDataFunc(profile)
+
+			if c.String("output") == "json" {
+				f = formatter.NewJSONFormatter()
+				getter = func() interface{} { return profile }
+			}
+
+			out, err := f.Format(getter)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(out)
+			return nil
 		},
 	}
 }
@@ -322,11 +345,18 @@ func searchDataFunc(profiles []profilesv1.ProfileDescription) func() interface{}
 	}
 }
 
-func printProfile(profile profilesv1.ProfileDescription) error {
-	out, err := yaml.Marshal(profile)
-	if err != nil {
-		return err
+func showDataFunc(profile profilesv1.ProfileDescription) func() interface{} {
+	return func() interface{} {
+		return formatter.TableContents{
+			Data: [][]string{
+				{"Catalog", profile.Catalog},
+				{"Name", profile.Name},
+				{"Version", profile.Version},
+				{"Description", profile.Description},
+				{"URL", profile.URL},
+				{"Maintainer", profile.Maintainer},
+				{"Prerequisites", strings.Join(profile.Prerequisites, ", ")},
+			},
+		}
 	}
-	fmt.Println(string(out))
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/fluxcd/helm-controller/api v0.10.0
 	github.com/jenkins-x/go-scm v1.6.18
+	github.com/olekukonko/tablewriter v0.0.0-20210304033056-74c60be0ef68
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -509,6 +511,8 @@ github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtb
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.0-20210304033056-74c60be0ef68 h1:wlMpGnqIUR/FmgvZ47yXdZfJ/FpJDSTR88AjimF3RXE=
+github.com/olekukonko/tablewriter v0.0.0-20210304033056-74c60be0ef68/go.mod h1:8Hf+pH6thup1sPZPD+NLg7d6vbpsdilu9CPIeikvgMQ=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -589,6 +593,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -1,0 +1,7 @@
+package formatter
+
+// Formatter formats data
+type Formatter interface {
+	// Format will call the getter func and render the returned data
+	Format(getter func() interface{}) (string, error)
+}

--- a/pkg/formatter/formatter_suite_test.go
+++ b/pkg/formatter/formatter_suite_test.go
@@ -1,0 +1,13 @@
+package formatter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFormatter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Formatter Suite")
+}

--- a/pkg/formatter/json.go
+++ b/pkg/formatter/json.go
@@ -1,0 +1,22 @@
+package formatter
+
+import (
+	"encoding/json"
+)
+
+type jsonFormatter struct{}
+
+// NewJSONFormatter formats output into json
+func NewJSONFormatter() jsonFormatter {
+	return jsonFormatter{}
+}
+
+// Format returns the Marshalled json output
+func (f jsonFormatter) Format(data func() interface{}) (string, error) {
+	out, err := json.MarshalIndent(data(), "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}

--- a/pkg/formatter/json_test.go
+++ b/pkg/formatter/json_test.go
@@ -1,0 +1,23 @@
+package formatter_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/pctl/pkg/formatter"
+	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
+)
+
+var _ = Describe("JsonFormater", func() {
+	It("formats output as json", func() {
+		jsonFormatter := formatter.NewJSONFormatter()
+		dataFunc := func() interface{} {
+			return profilesv1.ProfileDescription{Name: "foo", Catalog: "bar"}
+		}
+		out, err := jsonFormatter.Format(dataFunc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal(`{
+  "name": "foo",
+  "catalog": "bar"
+}`))
+	})
+})

--- a/pkg/formatter/table.go
+++ b/pkg/formatter/table.go
@@ -1,0 +1,58 @@
+package formatter
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type tableFormatter struct {
+	table  *tablewriter.Table
+	buffer *bytes.Buffer
+}
+
+// TableContents represents the contents of a table
+type TableContents struct {
+	Headers []string
+	Data    [][]string
+}
+
+// NewTableFormatter returns a table formatter
+func NewTableFormatter() tableFormatter {
+	buf := &bytes.Buffer{}
+	return tableFormatter{
+		table:  newDefaultTable(buf),
+		buffer: buf,
+	}
+}
+
+// Format receives column names and table data and creates a table in the writer
+func (f tableFormatter) Format(contentFunc func() interface{}) (string, error) {
+	contents, ok := contentFunc().(TableContents)
+	if !ok {
+		return "", errors.New("func returned wrong type for table formatter. wanted formatter.TableContents")
+	}
+
+	f.table.SetHeader(contents.Headers)
+	f.table.AppendBulk(contents.Data)
+	f.table.Render()
+
+	return f.buffer.String(), nil
+}
+
+func newDefaultTable(buf *bytes.Buffer) *tablewriter.Table {
+	table := tablewriter.NewWriter(buf)
+	table.SetAutoWrapText(false)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAutoFormatHeaders(true)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t")
+	table.SetNoWhiteSpace(true)
+	return table
+}

--- a/pkg/formatter/table_test.go
+++ b/pkg/formatter/table_test.go
@@ -1,0 +1,36 @@
+package formatter_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/pctl/pkg/formatter"
+)
+
+var _ = Describe("Table", func() {
+	var tableFormatter formatter.Formatter
+	BeforeEach(func() {
+		tableFormatter = formatter.NewTableFormatter()
+	})
+
+	It("formats output in a table", func() {
+		contFunc := func() interface{} {
+			return formatter.TableContents{
+				Headers: []string{"col1", "col2"},
+				Data:    [][]string{{"dat1", "dat2"}},
+			}
+		}
+		out, err := tableFormatter.Format(contFunc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("COL1\tCOL2 \ndat1\tdat2\t\n"))
+	})
+
+	When("the wrong type is returned in the getter func", func() {
+		It("returns an error", func() {
+			contFunc := func() interface{} {
+				return "not a table contents obj"
+			}
+			_, err := tableFormatter.Format(contFunc)
+			Expect(err).To(MatchError("func returned wrong type for table formatter. wanted formatter.TableContents"))
+		})
+	})
+})

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -24,7 +24,37 @@ var _ = Describe("PCTL", func() {
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(string(session.Out.Contents())).To(ContainSubstring("weaveworks-nginx: This installs nginx"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("CATALOG/PROFILE               	VERSION	DESCRIPTION                     \n" +
+				"nginx-catalog/weaveworks-nginx	0.0.1  	This installs nginx.           \t\n" +
+				"nginx-catalog/some-other-nginx	       	This installs some other nginx.\t\n"),
+			)
+		})
+
+		When("-o is set to json", func() {
+			It("returns the matching profiles in json", func() {
+				cmd := exec.Command(binaryPath, "search", "-o", "json", "nginx")
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(string(session.Out.Contents())).To(ContainSubstring(`[
+  {
+    "name": "weaveworks-nginx",
+    "description": "This installs nginx.",
+    "version": "0.0.1",
+    "catalog": "nginx-catalog",
+    "url": "https://github.com/weaveworks/nginx-profile",
+    "maintainer": "weaveworks (https://github.com/weaveworks/profiles)",
+    "prerequisites": [
+      "Kubernetes 1.18+"
+    ]
+  },
+  {
+    "name": "some-other-nginx",
+    "description": "This installs some other nginx.",
+    "catalog": "nginx-catalog"
+  }
+]`))
+			})
 		})
 
 		When("kubeconfig is incorrectly set", func() {


### PR DESCRIPTION
### Description

Closes #20.

This adds `--output/-o` flags to both search and show commands.

The default is `table` with `json` as an option. I have implented an interface for the `formatter` but I am not sure how I feel about it.

The `JSONFormatter` is very basic, as we just want to throw go objects into a marshal and not much more than this.

The `TableFormatter` is fairly simple, and hopefully is flexible enough so that people can format output as they like.

This also covers the improvement in #20 which lets users see which catalog a profile is in from the search output, and gives them something easily copy-pastable.

Demo:

```sh
$ pctl search nginx
CATALOG/PROFILE                         VERSION DESCRIPTION
nginx-catalog-1/weaveworks-nginx        0.0.1   This installs nginx.
nginx-catalog-1/some-other-nginx        1.0.1   This installs some other nginx.

$ pctl search -o json nginx # more detail spat out here which I think will be useful to folks, can trim if wanted.
[
    {
        "name": "weaveworks-nginx",
        "description": "This installs nginx.",
        "version": "0.0.1",
        "catalog": "nginx-catalog-1",
        "url": "https://github.com/weaveworks/nginx-profile",
        "maintainer": "weaveworks (https://github.com/weaveworks/profiles)",
        "prerequisites": [
            "Kubernetes 1.18+"
        ]
    },
... etc
]
```

```sh
$ pctl show nginx-catalog-1/weaveworks-nginx
Catalog         nginx-catalog-1
Name            weaveworks-nginx
Version         0.0.1
Description     This installs nginx.
URL             https://github.com/weaveworks/nginx-profile
Maintainer      weaveworks (https://github.com/weaveworks/profiles)
Prerequisites   Kubernetes 1.18+

$ pctl show -o json nginx-catalog-1/weaveworks-nginx
{
    "name": "weaveworks-nginx",
    "description": "This installs nginx.",
    "version": "0.0.1",
    "catalog": "nginx-catalog-1",
    "url": "https://github.com/weaveworks/nginx-profile",
    "maintainer": "weaveworks (https://github.com/weaveworks/profiles)",
    "prerequisites": [
        "Kubernetes 1.18+"
    ]
} 
```


### Checklist
- [x] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
