### PR TITLE
Install latest profile if no version is provided

### DIFF
--- a/cmd/pctl/install.go
+++ b/cmd/pctl/install.go
@@ -108,6 +108,10 @@ func install(c *cli.Context) error {
 	catalogName, profileName := parts[0], parts[1]
 
 	fmt.Printf("generating subscription for profile %s/%s:\n\n", catalogName, profileName)
+	version := "latest"
+	if len(parts) == 3 {
+		version = parts[2]
+	}
 	cfg := catalog.InstallConfig{
 		Branch:        branch,
 		CatalogName:   catalogName,
@@ -117,9 +121,7 @@ func install(c *cli.Context) error {
 		ProfileName:   profileName,
 		SubName:       subName,
 		Directory:     dir,
-	}
-	if len(parts) == 3 {
-		cfg.Version = parts[2]
+		Version:       version,
 	}
 	return catalog.Install(cfg)
 }

--- a/pkg/catalog/install.go
+++ b/pkg/catalog/install.go
@@ -51,11 +51,11 @@ func Install(cfg InstallConfig) error {
 		},
 		Spec: profilesv1.ProfileSubscriptionSpec{
 			ProfileURL: profile.URL,
-			Version:    filepath.Join(cfg.ProfileName, cfg.Version),
+			Version:    filepath.Join(profile.Name, profile.Version),
 			ProfileCatalogDescription: &profilesv1.ProfileCatalogDescription{
 				Catalog: cfg.CatalogName,
-				Version: cfg.Version,
-				Profile: cfg.ProfileName,
+				Version: profile.Version,
+				Profile: profile.Name,
 			},
 		},
 	}

--- a/pkg/catalog/show.go
+++ b/pkg/catalog/show.go
@@ -11,12 +11,12 @@ import (
 )
 
 // Show queries the catalog at catalogURL for a profile matching the provided profileName
-func Show(catalogClient CatalogClient, catalogName, profileName, catalogVersion string) (profilesv1.ProfileDescription, error) {
+func Show(catalogClient CatalogClient, catalogName, profileName, profileVersion string) (profilesv1.ProfileDescription, error) {
 	u, err := url.Parse("/profiles")
 	if err != nil {
 		return profilesv1.ProfileDescription{}, err
 	}
-	u.Path = path.Join(u.Path, catalogName, profileName, catalogVersion)
+	u.Path = path.Join(u.Path, catalogName, profileName, profileVersion)
 	data, code, err := catalogClient.DoRequest(u.String(), nil)
 	if err != nil {
 		return profilesv1.ProfileDescription{}, fmt.Errorf("failed to do request: %w", err)
@@ -26,7 +26,7 @@ func Show(catalogClient CatalogClient, catalogName, profileName, catalogVersion 
 		if code == http.StatusNotFound {
 			return profilesv1.ProfileDescription{},
 				fmt.Errorf("unable to find profile %q in catalog %q (with version if provided: %s)",
-					profileName, catalogName, catalogVersion)
+					profileName, catalogName, profileVersion)
 		}
 		return profilesv1.ProfileDescription{}, fmt.Errorf("failed to fetch profile from catalog, status code %d", code)
 	}


### PR DESCRIPTION
### Description

We will pass "latest" to the catalog API calls if no version is provided. Sister PR https://github.com/weaveworks/profiles/pull/126

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
