### PR TITLE
Generate artifact files with 0644 perms

### DIFF
--- a/pkg/catalog/install.go
+++ b/pkg/catalog/install.go
@@ -68,23 +68,6 @@ func Install(cfg InstallConfig) error {
 		return fmt.Errorf("failed to generate artifacts: %w", err)
 	}
 
-	e := kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, nil, nil, kjson.SerializerOptions{Yaml: true, Strict: true})
-	generateOutput := func(filename string, o runtime.Object) error {
-		f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
-		if err != nil {
-			return err
-		}
-		defer func(f *os.File) {
-			if err := f.Close(); err != nil {
-				fmt.Printf("Failed to properly close file %s\n", f.Name())
-			}
-		}(f)
-		if err := e.Encode(o, f); err != nil {
-			return err
-		}
-		return nil
-	}
-
 	profileRootdir := filepath.Join(cfg.Directory, cfg.ProfileName)
 	artifactsRootDir := filepath.Join(profileRootdir, "artifacts")
 
@@ -130,6 +113,24 @@ func getProfileSpec(cfg InstallConfig) (profilesv1.ProfileSubscriptionSpec, erro
 			Profile: p.Name,
 		},
 	}, nil
+}
+
+func generateOutput(filename string, o runtime.Object) error {
+	e := kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, nil, nil, kjson.SerializerOptions{Yaml: true, Strict: true})
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func(f *os.File) {
+		if err := f.Close(); err != nil {
+			fmt.Printf("Failed to properly close file %s\n", f.Name())
+		}
+	}(f)
+	if err := e.Encode(o, f); err != nil {
+		return err
+	}
+	return nil
+
 }
 
 // CreatePullRequest creates a pull request from the current changes.

--- a/pkg/catalog/install_test.go
+++ b/pkg/catalog/install_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -111,6 +112,9 @@ var _ = Describe("Install", func() {
 			profileFile := filepath.Join(profileDir, "profile.yaml")
 			artifactFile := filepath.Join(profileDir, "artifacts", "foo", "kustomize.yaml")
 			Expect(files).To(ConsistOf(profileFile, artifactFile))
+
+			Expect(hasCorrectFilePerms(profileFile)).To(BeTrue())
+			Expect(hasCorrectFilePerms(artifactFile)).To(BeTrue())
 
 			content, err := ioutil.ReadFile(profileFile)
 			Expect(err).NotTo(HaveOccurred())
@@ -311,3 +315,9 @@ status: {}
 		})
 	})
 })
+
+func hasCorrectFilePerms(file string) bool {
+	info, err := os.Stat(file)
+	Expect(err).NotTo(HaveOccurred())
+	return strconv.FormatUint(uint64(info.Mode().Perm()), 8) == strconv.FormatInt(0644, 8)
+}


### PR DESCRIPTION

### Description

We previously created with `0777` which, depending on the caller's local
`umask`, would result in files created with `0755` or `0775` (assuming a
typical `umask` setting of `0022` or `0002`).

This commit chooses `0644` as a suitably permissive mode for files. `0664`
would also have been okay, but again this is more likely to be
affected by individual umasks so is less predictable.

Closes https://github.com/weaveworks/pctl/issues/75

### Checklist
- [x] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
