### PR TITLE
use installation terminology instead of subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ weaveworks-nginx
 │   └── nginx-deployment
 │       ├── GitRepository.yaml
 │       └── Kustomization.yaml
-└── profile.yaml
+└── profile-installation.yaml
 
 ```
 
-The `profile.yaml` is the top-level Profile installation object. It describes the profile installation. The artifacts
+The `profile-installation.yaml` is the top-level Profile installation object. It describes the profile installation. The artifacts
 directory contains all of the resources required for deploying the profile. Each of the artifacts corresponds to a
 [Flux 2 resource](https://fluxcd.io/docs/components/).
 
@@ -116,20 +116,20 @@ tree
 │   │       ├── Chart.lock
 │   │       ├── ...
 │   │       └── values.yaml
-│   └── profile.yaml
+│   └── profile-installation.yaml
 └── weaveworks-nginx
     ├── README.md
     ├── nginx
     │   └── deployment
     │       └── deployment.yaml
-    └── profile.yaml
+    └── profile-installation.yaml
 ```
 
 Given a development branch called `devel` to install the `bitnami-nginx` profile from this repository, call `install`
 with the following parameters:
 
 ```
-pctl install --subscription-name pctl-profile \
+pctl install --name pctl-profile \
              --namespace default \
              --profile-branch devel \
              --profile-url https://github.com/<usr>/<repo> \
@@ -153,7 +153,7 @@ Provide the following information when running install: `--git-repository <names
 This looks as follows if installing via a URL:
 
 ```
-pctl install --subscription-name pctl-profile \
+pctl install --name pctl-profile \
              --namespace [default] \
              --profile-branch [main] \
              --profile-url git@github.com:org/private-profile-repo \

--- a/cmd/pctl/install.go
+++ b/cmd/pctl/install.go
@@ -19,15 +19,15 @@ import (
 func installCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "install",
-		Usage: "generate a profile subscription",
-		UsageText: "To install from a profile catalog entry: pctl --catalog-url <URL> install --subscription-name pctl-profile --namespace default --profile-branch main --config-secret configmap-name <CATALOG>/<PROFILE>[/<VERSION>]\n   " +
-			"To install directly from a profile repository: pctl install --subscription-name pctl-profile --namespace default --profile-branch development --profile-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx",
+		Usage: "generate a profile installation",
+		UsageText: "To install from a profile catalog entry: pctl --catalog-url <URL> install --name pctl-profile --namespace default --profile-branch main --config-secret configmap-name <CATALOG>/<PROFILE>[/<VERSION>]\n   " +
+			"To install directly from a profile repository: pctl install --name pctl-profile --namespace default --profile-branch development --profile-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:        "subscription-name",
+				Name:        "name",
 				DefaultText: "pctl-profile",
 				Value:       "pctl-profile",
-				Usage:       "The name of the subscription.",
+				Usage:       "The name of the installation.",
 			},
 			&cli.StringFlag{
 				Name:        "namespace",
@@ -146,7 +146,7 @@ func install(c *cli.Context) error {
 	}
 
 	branch := c.String("profile-branch")
-	subName := c.String("subscription-name")
+	subName := c.String("name")
 	namespace := c.String("namespace")
 	configValues := c.String("config-secret")
 	dir := c.String("out")
@@ -159,7 +159,7 @@ func install(c *cli.Context) error {
 	} else {
 		name = fmt.Sprintf("%s/%s", catalogName, profileName)
 	}
-	fmt.Printf("generating subscription for profile %s:\n\n", name)
+	fmt.Printf("generating installation for profile %s:\n\n", name)
 	r := &runner.CLIRunner{}
 	g := git.NewCLIGit(git.CLIGitConfig{}, r)
 	var (
@@ -214,7 +214,7 @@ func createPullRequest(c *cli.Context) error {
 		return errors.New("repo must be defined if create-pr is true")
 	}
 	if branch == "" {
-		branch = c.String("subscription-name") + "-" + uuid.NewString()[:6]
+		branch = c.String("name") + "-" + uuid.NewString()[:6]
 	}
 	fmt.Printf("Creating a PR to repo %s with base %s and branch %s\n", repo, base, branch)
 	r := &runner.CLIRunner{}

--- a/pkg/catalog/install.go
+++ b/pkg/catalog/install.go
@@ -48,14 +48,14 @@ type InstallConfig struct {
 	Directory string
 }
 
-// Install using the catalog at catalogURL and a profile matching the provided profileName generates a profile subscription
+// Install using the catalog at catalogURL and a profile matching the provided profileName generates a profile installation
 // and its artifacts
 func Install(cfg InstallConfig) error {
 	pSpec, err := getProfileSpec(cfg)
 	if err != nil {
 		return err
 	}
-	subscription := profilesv1.ProfileInstallation{
+	installation := profilesv1.ProfileInstallation{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ProfileInstallation",
 			APIVersion: "weave.works/v1alpha1",
@@ -67,7 +67,7 @@ func Install(cfg InstallConfig) error {
 		Spec: pSpec,
 	}
 	if cfg.ConfigMap != "" {
-		subscription.Spec.ValuesFrom = []helmv2.ValuesReference{
+		installation.Spec.ValuesFrom = []helmv2.ValuesReference{
 			{
 				Kind:      "ConfigMap",
 				Name:      cfg.SubName + "-values",
@@ -76,7 +76,7 @@ func Install(cfg InstallConfig) error {
 		}
 	}
 	profileRootdir := filepath.Join(cfg.Directory, cfg.ProfileName)
-	artifacts, err := cfg.ArtifactsMaker.MakeArtifacts(subscription)
+	artifacts, err := cfg.ArtifactsMaker.MakeArtifacts(installation)
 	if err != nil {
 		return fmt.Errorf("failed to generate artifacts: %w", err)
 	}
@@ -100,7 +100,7 @@ func Install(cfg InstallConfig) error {
 		}
 	}
 
-	return generateOutput(filepath.Join(profileRootdir, "profile.yaml"), &subscription)
+	return generateOutput(filepath.Join(profileRootdir, "profile-installation.yaml"), &installation)
 }
 
 // getRepositoryLocalArtifacts clones all repository local artifacts so they can be copied over to the flux repository.

--- a/pkg/catalog/install_test.go
+++ b/pkg/catalog/install_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Install", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			profileFile := filepath.Join(profileDir, "profile.yaml")
+			profileFile := filepath.Join(profileDir, "profile-installation.yaml")
 			artifactFile := filepath.Join(profileDir, "artifacts", "foo", "kustomize.yaml")
 			Expect(files).To(ConsistOf(profileFile, artifactFile))
 
@@ -211,7 +211,7 @@ status: {}
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				profileFile := filepath.Join(profileDir, "profile.yaml")
+				profileFile := filepath.Join(profileDir, "profile-installation.yaml")
 				artifactsDir := filepath.Join(profileDir, "artifacts")
 				artifactsFooDir := filepath.Join(profileDir, "artifacts", "foo")
 				artifactFile := filepath.Join(profileDir, "artifacts", "foo", "kustomize.yaml")

--- a/pkg/catalog/list.go
+++ b/pkg/catalog/list.go
@@ -5,19 +5,19 @@ import (
 
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/weaveworks/pctl/pkg/subscription"
+	"github.com/weaveworks/pctl/pkg/installation"
 	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
 // ProfileData data containing profile and available version update for format printing.
 type ProfileData struct {
-	Profile                 subscription.InstallationSummary
+	Profile                 installation.Summary
 	AvailableVersionUpdates []string
 }
 
 // List will fetch all installed profiles on the cluster and check if there are updated versions available.
 func List(k8sClient runtimeclient.Client, catalogClient CatalogClient) ([]ProfileData, error) {
-	profiles, err := subscription.NewManager(k8sClient).List()
+	profiles, err := installation.NewManager(k8sClient).List()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/catalog/list_test.go
+++ b/pkg/catalog/list_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/weaveworks/pctl/pkg/catalog"
 	"github.com/weaveworks/pctl/pkg/catalog/fakes"
-	"github.com/weaveworks/pctl/pkg/subscription"
+	"github.com/weaveworks/pctl/pkg/installation"
 )
 
 var _ = Describe("List", func() {
@@ -85,7 +85,7 @@ var _ = Describe("List", func() {
 		Expect(err).NotTo(HaveOccurred())
 		expected := []catalog.ProfileData{
 			{
-				Profile: subscription.InstallationSummary{
+				Profile: installation.Summary{
 					Name:      "sub1",
 					Namespace: "default",
 					Profile:   "weaveworks-nginx",
@@ -118,7 +118,7 @@ var _ = Describe("List", func() {
 			Expect(err).NotTo(HaveOccurred())
 			expected := []catalog.ProfileData{
 				{
-					Profile: subscription.InstallationSummary{
+					Profile: installation.Summary{
 						Name:      "sub1",
 						Namespace: "default",
 						Profile:   "weaveworks-nginx",
@@ -150,7 +150,7 @@ var _ = Describe("List", func() {
 			fakeRuntimeClient = fake.NewClientBuilder().Build()
 			fakeCatalogClient.DoRequestReturns(nil, 200, nil)
 			_, err := catalog.List(fakeRuntimeClient, fakeCatalogClient)
-			Expect(err).To(MatchError("failed to list profile subscriptions: no kind is registered for the type v1alpha1.ProfileInstallationList in scheme \"pkg/runtime/scheme.go:100\""))
+			Expect(err).To(MatchError("failed to list profile installations: no kind is registered for the type v1alpha1.ProfileInstallationList in scheme \"pkg/runtime/scheme.go:100\""))
 		})
 	})
 
@@ -231,7 +231,7 @@ var _ = Describe("List", func() {
 			Expect(err).NotTo(HaveOccurred())
 			expected := []catalog.ProfileData{
 				{
-					Profile: subscription.InstallationSummary{
+					Profile: installation.Summary{
 						Name:      "sub1",
 						Namespace: "default",
 						Profile:   "weaveworks-nginx",
@@ -244,7 +244,7 @@ var _ = Describe("List", func() {
 					AvailableVersionUpdates: []string{"v0.1.1"},
 				},
 				{
-					Profile: subscription.InstallationSummary{
+					Profile: installation.Summary{
 						Name:      "sub2",
 						Namespace: "namespace2",
 						Profile:   "weaveworks-nginx-2",
@@ -257,7 +257,7 @@ var _ = Describe("List", func() {
 					AvailableVersionUpdates: []string{"-"},
 				},
 				{
-					Profile: subscription.InstallationSummary{
+					Profile: installation.Summary{
 						Name:      "sub3",
 						Namespace: "namespace3",
 						Profile:   "weaveworks-nginx-3",

--- a/pkg/cluster/testdata/prepare.yaml
+++ b/pkg/cluster/testdata/prepare.yaml
@@ -148,14 +148,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
-  name: profilesubscriptions.weave.works
+  name: profileinstallations.weave.works
 spec:
   group: weave.works
   names:
-    kind: ProfileSubscription
-    listKind: ProfileSubscriptionList
-    plural: profilesubscriptions
-    singular: profilesubscription
+    kind: Profileinstallation
+    listKind: ProfileinstallationList
+    plural: profileinstallations
+    singular: profileinstallation
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -171,7 +171,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: ProfileSubscription is the Schema for the profilesubscriptions API
+          description: Profileinstallation is the Schema for the profilesubscriptions API
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -182,7 +182,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ProfileSubscriptionSpec defines the desired state of a ProfileSubscription
+              description: ProfileinstallationSpec defines the desired state of a ProfileSubscription
               properties:
                 branch:
                   default: main
@@ -226,10 +226,10 @@ spec:
                   type: array
               type: object
             status:
-              description: ProfileSubscriptionStatus defines the observed state of ProfileSubscription
+              description: ProfileinstallationStatus defines the observed state of ProfileSubscription
               properties:
                 conditions:
-                  description: Conditions holds the conditions for the ProfileSubscription
+                  description: Conditions holds the conditions for the Profileinstallation
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                     properties:
@@ -420,7 +420,7 @@ rules:
   - apiGroups:
       - weave.works
     resources:
-      - profilesubscriptions
+      - profileinstallations
     verbs:
       - create
       - delete
@@ -432,13 +432,13 @@ rules:
   - apiGroups:
       - weave.works
     resources:
-      - profilesubscriptions/finalizers
+      - profileinstallations/finalizers
     verbs:
       - update
   - apiGroups:
       - weave.works
     resources:
-      - profilesubscriptions/status
+      - profileinstallations/status
     verbs:
       - get
       - patch

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -42,7 +42,7 @@ var _ = Describe("git", func() {
 		})
 		When("normal flow operations", func() {
 			It("detects if there are changes to be committed if stats returns a list of files", func() {
-				runner.RunReturns([]byte("profile_subscription.yaml"), nil)
+				runner.RunReturns([]byte("profile_installation.yaml"), nil)
 				g := git.NewCLIGit(git.CLIGitConfig{
 					Directory: "location",
 					Branch:    "main",
@@ -145,7 +145,7 @@ var _ = Describe("git", func() {
 	Context("Commit", func() {
 		When("normal flow operations", func() {
 			It("commit changes", func() {
-				runner.RunReturnsOnCall(0, []byte("profile_subscription.yaml"), nil)
+				runner.RunReturnsOnCall(0, []byte("profile_installation.yaml"), nil)
 				g := git.NewCLIGit(git.CLIGitConfig{
 					Directory: "location",
 					Branch:    "main",
@@ -164,7 +164,7 @@ var _ = Describe("git", func() {
 		})
 		When("the flow is disrupted with errors", func() {
 			It("returns a sensible wrapped error", func() {
-				runner.RunReturnsOnCall(0, []byte("profile_subscription.yaml"), nil)
+				runner.RunReturnsOnCall(0, []byte("profile_installation.yaml"), nil)
 				runner.RunReturnsOnCall(1, []byte(""), errors.New("nope"))
 				g := git.NewCLIGit(git.CLIGitConfig{
 					Directory: "location",

--- a/pkg/installation/installation_suite_test.go
+++ b/pkg/installation/installation_suite_test.go
@@ -1,4 +1,4 @@
-package subscription_test
+package installation_test
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestProfile(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Subscription Suite")
+	RunSpecs(t, "Installation Suite")
 }

--- a/pkg/installation/list.go
+++ b/pkg/installation/list.go
@@ -1,4 +1,4 @@
-package subscription
+package installation
 
 import (
 	"fmt"
@@ -6,8 +6,8 @@ import (
 	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 )
 
-// InstallationSummary contains a summary of a subscription
-type InstallationSummary struct {
+// Summary contains a summary of a installation
+type Summary struct {
 	Name      string
 	Namespace string
 	Version   string
@@ -18,15 +18,15 @@ type InstallationSummary struct {
 	URL       string
 }
 
-// List returns a list of subscriptions
-func (sm *Manager) List() ([]InstallationSummary, error) {
-	var subscriptions profilesv1.ProfileInstallationList
-	err := sm.kClient.List(sm.ctx, &subscriptions)
+// List returns a list of installations
+func (sm *Manager) List() ([]Summary, error) {
+	var installations profilesv1.ProfileInstallationList
+	err := sm.kClient.List(sm.ctx, &installations)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list profile subscriptions: %w", err)
+		return nil, fmt.Errorf("failed to list profile installations: %w", err)
 	}
-	var descriptions []InstallationSummary
-	for _, sub := range subscriptions.Items {
+	var descriptions []Summary
+	for _, sub := range installations.Items {
 		version := "-"
 		profile := "-"
 		catalog := "-"
@@ -49,7 +49,7 @@ func (sm *Manager) List() ([]InstallationSummary, error) {
 				url = sub.Spec.Source.URL
 			}
 		}
-		descriptions = append(descriptions, InstallationSummary{
+		descriptions = append(descriptions, Summary{
 			Name:      sub.Name,
 			Namespace: sub.Namespace,
 			Version:   version,

--- a/pkg/installation/list_test.go
+++ b/pkg/installation/list_test.go
@@ -1,11 +1,11 @@
-package subscription_test
+package installation_test
 
 import (
 	"context"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/weaveworks/pctl/pkg/subscription"
+	"github.com/weaveworks/pctl/pkg/installation"
 	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +15,7 @@ import (
 
 var _ = Describe("List", func() {
 	var (
-		sm              *subscription.Manager
+		sm              *installation.Manager
 		fakeClient      client.Client
 		profileTypeMeta = metav1.TypeMeta{
 			Kind:       "ProfileInstallation",
@@ -85,14 +85,14 @@ var _ = Describe("List", func() {
 		Expect(fakeClient.Create(context.TODO(), pSub2)).To(Succeed())
 		Expect(fakeClient.Create(context.TODO(), pSub3)).To(Succeed())
 
-		sm = subscription.NewManager(fakeClient)
+		sm = installation.NewManager(fakeClient)
 	})
 
 	It("returns a list of profiles deployed in the cluster", func() {
 		subs, err := sm.List()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(subs).To(ConsistOf(
-			subscription.InstallationSummary{
+			installation.Summary{
 				Name:      sub1,
 				Namespace: namespace1,
 				Version:   version,
@@ -102,7 +102,7 @@ var _ = Describe("List", func() {
 				Path:      "-",
 				URL:       "https://github.com/org/repo-name",
 			},
-			subscription.InstallationSummary{
+			installation.Summary{
 				Name:      sub2,
 				Namespace: namespace2,
 				Version:   "-",
@@ -112,7 +112,7 @@ var _ = Describe("List", func() {
 				Path:      "-",
 				URL:       "https://github.com/org/repo-name",
 			},
-			subscription.InstallationSummary{
+			installation.Summary{
 				Name:      sub3,
 				Namespace: namespace3,
 				Version:   "-",
@@ -130,12 +130,12 @@ var _ = Describe("List", func() {
 			//remove profilesv1 from scheme
 			scheme := runtime.NewScheme()
 			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
-			sm = subscription.NewManager(fakeClient)
+			sm = installation.NewManager(fakeClient)
 		})
 
 		It("returns an error", func() {
 			_, err := sm.List()
-			Expect(err).To(MatchError(ContainSubstring("failed to list profile subscriptions:")))
+			Expect(err).To(MatchError(ContainSubstring("failed to list profile installations:")))
 		})
 	})
 })

--- a/pkg/installation/manager.go
+++ b/pkg/installation/manager.go
@@ -1,4 +1,4 @@
-package subscription
+package installation
 
 import (
 	"context"
@@ -6,13 +6,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Manager manages getting and list profile subscriptions
+// Manager manages getting and list profile installations
 type Manager struct {
 	kClient client.Client
 	ctx     context.Context
 }
 
-// NewManager returns a SubscriptionManager
+// NewManager returns a installationManager
 func NewManager(kClient client.Client) *Manager {
 	return &Manager{
 		kClient: kClient,

--- a/pkg/profile/artifact.go
+++ b/pkg/profile/artifact.go
@@ -66,16 +66,16 @@ func (pa *ProfilesArtifactsMaker) MakeArtifacts(installation profilesv1.ProfileI
 }
 
 func (p *Profile) profileRepo() string {
-	if p.subscription.Spec.Source.Tag != "" {
-		return p.subscription.Spec.Source.URL + ":" + p.subscription.Spec.Source.Tag
+	if p.installation.Spec.Source.Tag != "" {
+		return p.installation.Spec.Source.URL + ":" + p.installation.Spec.Source.Tag
 	}
-	return p.subscription.Spec.Source.URL + ":" + p.subscription.Spec.Source.Branch + ":" + p.subscription.Spec.Source.Path
+	return p.installation.Spec.Source.URL + ":" + p.installation.Spec.Source.Branch + ":" + p.installation.Spec.Source.Path
 }
 
 // makeArtifacts will be part of the artifacts maker and not profiles.
 func (p *Profile) makeArtifacts(profileRepos []string, gitClient git.Git) ([]Artifact, error) {
 	var artifacts []Artifact
-	profileRepoPath := p.subscription.Spec.Source.Path
+	profileRepoPath := p.installation.Spec.Source.Path
 
 	for _, artifact := range p.definition.Spec.Artifacts {
 		if err := validateArtifact(artifact); err != nil {
@@ -97,7 +97,7 @@ func (p *Profile) makeArtifacts(profileRepos []string, gitClient git.Git) ([]Art
 			if err != nil {
 				return nil, fmt.Errorf("failed to get profile definition %s on branch %s: %w", artifact.Profile.Source.URL, branchOrTag, err)
 			}
-			nestedProfile := p.subscription.DeepCopyObject().(*profilesv1.ProfileInstallation)
+			nestedProfile := p.installation.DeepCopyObject().(*profilesv1.ProfileInstallation)
 			nestedProfile.Spec.Source.URL = artifact.Profile.Source.URL
 			nestedProfile.Spec.Source.Branch = artifact.Profile.Source.Branch
 			nestedProfile.Spec.Source.Tag = artifact.Profile.Source.Tag
@@ -132,11 +132,11 @@ func (p *Profile) makeArtifacts(profileRepos []string, gitClient git.Git) ([]Art
 					return nil, fmt.Errorf("in case of local resources, the flux gitrepository object's details must be provided")
 				}
 				helmRelease.Spec.Chart.Spec.Chart = filepath.Join(p.rootDir, "artifacts", artifact.Name, artifact.Chart.Path)
-				branch := p.subscription.Spec.Source.Branch
-				if p.subscription.Spec.Source.Tag != "" {
-					branch = p.subscription.Spec.Source.Tag
+				branch := p.installation.Spec.Source.Branch
+				if p.installation.Spec.Source.Tag != "" {
+					branch = p.installation.Spec.Source.Tag
 				}
-				a.RepoURL = p.subscription.Spec.Source.URL
+				a.RepoURL = p.installation.Spec.Source.URL
 				a.SparseFolder = p.definition.Name
 				a.Branch = branch
 				a.PathsToCopy = append(a.PathsToCopy, artifact.Chart.Path)
@@ -152,11 +152,11 @@ func (p *Profile) makeArtifacts(profileRepos []string, gitClient git.Git) ([]Art
 			}
 			path := filepath.Join(p.rootDir, "artifacts", artifact.Name, artifact.Kustomize.Path)
 			a.Objects = append(a.Objects, p.makeKustomization(artifact, path))
-			branch := p.subscription.Spec.Source.Branch
-			if p.subscription.Spec.Source.Tag != "" {
-				branch = p.subscription.Spec.Source.Tag
+			branch := p.installation.Spec.Source.Branch
+			if p.installation.Spec.Source.Tag != "" {
+				branch = p.installation.Spec.Source.Tag
 			}
-			a.RepoURL = p.subscription.Spec.Source.URL
+			a.RepoURL = p.installation.Spec.Source.URL
 			a.SparseFolder = p.definition.Name
 			a.Branch = branch
 			a.PathsToCopy = append(a.PathsToCopy, artifact.Kustomize.Path)
@@ -182,7 +182,7 @@ func (p *Profile) makeArtifactName(name string) string {
 	if strings.Contains(name, "/") {
 		name = filepath.Base(name)
 	}
-	return join(p.subscription.Name, p.definition.Name, name)
+	return join(p.installation.Name, p.definition.Name, name)
 }
 
 func join(s ...string) string {

--- a/pkg/profile/artifact_test.go
+++ b/pkg/profile/artifact_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	subscriptionName     = "mySub"
+	installationName     = "mySub"
 	namespace            = "default"
 	branch               = "main"
 	profileName1         = "profileName"
@@ -68,7 +68,7 @@ var _ = Describe("Profile", func() {
 		pSub = profilesv1.ProfileInstallation{
 			TypeMeta: profileTypeMeta,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      subscriptionName,
+				Name:      installationName,
 				Namespace: namespace,
 			},
 			Spec: profilesv1.ProfileInstallationSpec{
@@ -187,7 +187,7 @@ var _ = Describe("Profile", func() {
 				objects := nestedProfileArtifact.Objects
 				Expect(objects).To(HaveLen(1))
 
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", subscriptionName, profileName2, chartName1)
+				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName2, chartName1)
 				helmRelease := objects[0].(*helmv2.HelmRelease)
 
 				Expect(helmRelease.Name).To(Equal(helmReleaseName))
@@ -220,7 +220,7 @@ var _ = Describe("Profile", func() {
 
 				objects := pathBasedHelmArtifact.Objects
 
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", subscriptionName, profileName1, chartName2)
+				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, chartName2)
 				helmRelease := objects[0].(*helmv2.HelmRelease)
 				Expect(helmRelease.Name).To(Equal(helmReleaseName))
 				Expect(err).NotTo(HaveOccurred())
@@ -253,7 +253,7 @@ var _ = Describe("Profile", func() {
 
 				objects := kustomizeArtifact.Objects
 
-				kustomizeName := fmt.Sprintf("%s-%s-%s", subscriptionName, profileName1, kustomizeName1)
+				kustomizeName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, kustomizeName1)
 				kustomize := objects[0].(*kustomizev1.Kustomization)
 				Expect(kustomize.Name).To(Equal(kustomizeName))
 				Expect(kustomize.Spec.Path).To(Equal("root-dir/artifacts/kustomizeOneArtifactName/kustomize/artifact/path-one"))
@@ -276,12 +276,12 @@ var _ = Describe("Profile", func() {
 				objects := helmArtifact.Objects
 				Expect(objects).To(HaveLen(2))
 
-				helmRefName := fmt.Sprintf("%s-%s-%s", subscriptionName, "repo-name", helmChartChart1)
+				helmRefName := fmt.Sprintf("%s-%s-%s", installationName, "repo-name", helmChartChart1)
 				helmRepo := objects[1].(*sourcev1.HelmRepository)
 				Expect(helmRepo.Name).To(Equal(helmRefName))
 				Expect(helmRepo.Spec.URL).To(Equal(helmChartURL1))
 
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", subscriptionName, profileName1, helmChartName1)
+				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, helmChartName1)
 				helmRelease := objects[0].(*helmv2.HelmRelease)
 				Expect(helmRelease.Name).To(Equal(helmReleaseName))
 				Expect(helmRelease.Spec.Chart.Spec.Chart).To(Equal(helmChartChart1))
@@ -314,7 +314,7 @@ var _ = Describe("Profile", func() {
 				pSub = profilesv1.ProfileInstallation{
 					TypeMeta: profileTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      subscriptionName,
+						Name:      installationName,
 						Namespace: namespace,
 					},
 					Spec: profilesv1.ProfileInstallationSpec{
@@ -340,7 +340,7 @@ var _ = Describe("Profile", func() {
 
 					objects := pathBasedHelmArtifact.Objects
 
-					helmReleaseName := fmt.Sprintf("%s-%s-%s", subscriptionName, profileName1, chartName2)
+					helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, chartName2)
 					helmRelease := objects[0].(*helmv2.HelmRelease)
 					Expect(helmRelease.Name).To(Equal(helmReleaseName))
 					Expect(err).NotTo(HaveOccurred())
@@ -361,7 +361,7 @@ var _ = Describe("Profile", func() {
 				pSub = profilesv1.ProfileInstallation{
 					TypeMeta: profileTypeMeta,
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      subscriptionName,
+						Name:      installationName,
 						Namespace: namespace,
 					},
 					Spec: profilesv1.ProfileInstallationSpec{

--- a/pkg/profile/helm.go
+++ b/pkg/profile/helm.go
@@ -14,7 +14,7 @@ func (p *Profile) makeHelmRepository(url string, name string) *sourcev1.HelmRepo
 	return &sourcev1.HelmRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.makeHelmRepoName(name),
-			Namespace: p.subscription.ObjectMeta.Namespace,
+			Namespace: p.installation.ObjectMeta.Namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       sourcev1.HelmRepositoryKind,
@@ -27,9 +27,9 @@ func (p *Profile) makeHelmRepository(url string, name string) *sourcev1.HelmRepo
 }
 
 func (p *Profile) makeHelmRepoName(name string) string {
-	repoParts := strings.Split(p.subscription.Spec.Source.URL, "/")
+	repoParts := strings.Split(p.installation.Spec.Source.URL, "/")
 	repoName := repoParts[len(repoParts)-1]
-	return join(p.subscription.Name, repoName, name)
+	return join(p.installation.Name, repoName, name)
 }
 
 func (p *Profile) makeHelmRelease(artifact profilesv1.Artifact, repoPath string) *helmv2.HelmRelease {
@@ -42,7 +42,7 @@ func (p *Profile) makeHelmRelease(artifact profilesv1.Artifact, repoPath string)
 	helmRelease := &helmv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.makeArtifactName(artifact.Name),
-			Namespace: p.subscription.ObjectMeta.Namespace,
+			Namespace: p.installation.ObjectMeta.Namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       helmv2.HelmReleaseKind,
@@ -52,8 +52,8 @@ func (p *Profile) makeHelmRelease(artifact profilesv1.Artifact, repoPath string)
 			Chart: helmv2.HelmChartTemplate{
 				Spec: helmChartSpec,
 			},
-			Values:     p.subscription.Spec.Values,
-			ValuesFrom: p.subscription.Spec.ValuesFrom,
+			Values:     p.installation.Spec.Values,
+			ValuesFrom: p.installation.Spec.ValuesFrom,
 		},
 	}
 	return helmRelease
@@ -76,7 +76,7 @@ func (p *Profile) makeHelmChartSpec(chart string, version string) helmv2.HelmCha
 		SourceRef: helmv2.CrossNamespaceObjectReference{
 			Kind:      sourcev1.HelmRepositoryKind,
 			Name:      p.makeHelmRepoName(chart),
-			Namespace: p.subscription.ObjectMeta.Namespace,
+			Namespace: p.installation.ObjectMeta.Namespace,
 		},
 		Version: version,
 	}

--- a/pkg/profile/kustomize.go
+++ b/pkg/profile/kustomize.go
@@ -13,7 +13,7 @@ func (p *Profile) makeKustomization(artifact profilesv1.Artifact, repoPath strin
 	return &kustomizev1.Kustomization{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.makeArtifactName(artifact.Name),
-			Namespace: p.subscription.ObjectMeta.Namespace,
+			Namespace: p.installation.ObjectMeta.Namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       kustomizev1.KustomizationKind,
@@ -23,7 +23,7 @@ func (p *Profile) makeKustomization(artifact profilesv1.Artifact, repoPath strin
 			Path:            repoPath,
 			Interval:        metav1.Duration{Duration: time.Minute * 5},
 			Prune:           true,
-			TargetNamespace: p.subscription.ObjectMeta.Namespace,
+			TargetNamespace: p.installation.ObjectMeta.Namespace,
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
 				Kind:      sourcev1.GitRepositoryKind,
 				Name:      p.gitRepositoryName,

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -11,7 +11,7 @@ import (
 // managing profile artefacts (child resources)
 type Profile struct {
 	definition             profilesv1.ProfileDefinition
-	subscription           profilesv1.ProfileInstallation
+	installation           profilesv1.ProfileInstallation
 	nestedName             string
 	rootDir                string
 	gitRepositoryName      string
@@ -27,7 +27,7 @@ var getProfileDefinition = repo.GetProfileDefinition
 func newProfile(def profilesv1.ProfileDefinition, sub profilesv1.ProfileInstallation, rootDir, gitRepoNamespace, gitRepoName string) *Profile {
 	return &Profile{
 		definition:             def,
-		subscription:           sub,
+		installation:           sub,
 		gitRepositoryName:      gitRepoName,
 		gitRepositoryNamespace: gitRepoNamespace,
 		rootDir:                rootDir,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -180,7 +180,7 @@ var _ = Describe("PCTL", func() {
 	Context("list", func() {
 		var (
 			namespace        = "default"
-			subscriptionName = "long-name-to-ensure-padding"
+			installationName = "long-name-to-ensure-padding"
 			ctx              = context.TODO()
 			pSub             profilesv1.ProfileInstallation
 		)
@@ -190,10 +190,10 @@ var _ = Describe("PCTL", func() {
 			pSub = profilesv1.ProfileInstallation{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ProfileInstallation",
-					APIVersion: "profilesubscriptions.weave.works/v1alpha1",
+					APIVersion: "profileinstallations.weave.works/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      subscriptionName,
+					Name:      installationName,
 					Namespace: namespace,
 				},
 				Spec: profilesv1.ProfileInstallationSpec{
@@ -215,7 +215,7 @@ var _ = Describe("PCTL", func() {
 			Expect(kClient.Delete(ctx, &pSub)).Should(Succeed())
 		})
 
-		It("returns the subscriptions", func() {
+		It("returns the installations", func() {
 			listCmd := func() []string {
 				cmd := exec.Command(binaryPath, "list")
 				session, err := cmd.CombinedOutput()
@@ -230,12 +230,12 @@ var _ = Describe("PCTL", func() {
 		})
 
 		When("there are no available updates", func() {
-			It("returns the subscriptions", func() {
+			It("returns the installations", func() {
 				profileURL := "https://github.com/weaveworks/profiles-examples"
 				bitnamiSub := profilesv1.ProfileInstallation{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ProfileInstallation",
-						APIVersion: "profilesubscriptions.weave.works/v1alpha1",
+						APIVersion: "profileinstallations.weave.works/v1alpha1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bitnami-profile",
@@ -347,12 +347,12 @@ var _ = Describe("PCTL", func() {
 
 			By("creating the artifacts")
 			Expect(files).To(ContainElements(
-				"profile.yaml",
+				"profile-installation.yaml",
 				"artifacts/nginx-deployment/Kustomization.yaml",
 				"artifacts/nginx-deployment/nginx/deployment/deployment.yaml",
 			))
 
-			filename := filepath.Join(temp, "profile.yaml")
+			filename := filepath.Join(temp, "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
@@ -446,7 +446,7 @@ status: {}
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating the artifacts")
-				profilesDirProfile := filepath.Join(temp, "profile.yaml")
+				profilesDirProfile := filepath.Join(temp, "profile-installation.yaml")
 				profilesArtifacts := filepath.Join(temp, "artifacts")
 				profilesArtifactsChartDir := filepath.Join(profilesArtifacts, "nginx-server")
 				profilesArtifactsRelease := filepath.Join(profilesArtifactsChartDir, "HelmRelease.yaml")
@@ -459,7 +459,7 @@ status: {}
 					profilesArtifactsChart,
 					profilesArtifactsRelease,
 				))
-				filename := filepath.Join(temp, "profile.yaml")
+				filename := filepath.Join(temp, "profile-installation.yaml")
 				content, err := ioutil.ReadFile(filename)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
@@ -499,7 +499,7 @@ status: {}
 				Expect(err).NotTo(HaveOccurred())
 
 				By("creating the artifacts")
-				profilesDirProfile := filepath.Join(temp, "profile.yaml")
+				profilesDirProfile := filepath.Join(temp, "profile-installation.yaml")
 				profilesArtifacts := filepath.Join(temp, "artifacts")
 				profilesArtifactsDeployment := filepath.Join(temp, "artifacts", "nginx-server")
 				profilesArtifactsDeploymentKustomizationNginx := filepath.Join(temp, "artifacts", "nginx-server", "nginx")
@@ -514,7 +514,7 @@ status: {}
 					profilesArtifactsDeploymentKustomizationNginxChart,
 					profilesArtifactsDeploymentKustomizationNginxChartYaml,
 				))
-				filename := filepath.Join(temp, "profile.yaml")
+				filename := filepath.Join(temp, "profile-installation.yaml")
 				content, err := ioutil.ReadFile(filename)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
@@ -699,12 +699,12 @@ status: {}
 
 			By("creating the artifacts")
 			Expect(files).To(ContainElements(
-				"profile.yaml",
+				"profile-installation.yaml",
 				"artifacts/bitnami-nginx/HelmRelease.yaml",
 				"artifacts/bitnami-nginx/HelmRepository.yaml",
 			))
 
-			filename := filepath.Join(temp, "nginx", "profile.yaml")
+			filename := filepath.Join(temp, "nginx", "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1


### PR DESCRIPTION
### Description

Create a `profile-installation.yaml` file instead of a `profile.yaml` and use the `installation` naming convention instead of `subscription` everywhere. I also renamed `--subscription-name` to just `--name`
### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
