### PR TITLE
don't print table columns when no results found for list

### DIFF
--- a/cmd/pctl/list.go
+++ b/cmd/pctl/list.go
@@ -36,6 +36,12 @@ func listCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
+
+			if len(data) == 0 {
+				fmt.Println("no profiles installed")
+				return nil
+			}
+
 			var f formatter.Formatter
 			f = formatter.NewTableFormatter()
 			getter := listDataFunc(data)

--- a/pkg/catalog/list.go
+++ b/pkg/catalog/list.go
@@ -22,7 +22,6 @@ func List(k8sClient runtimeclient.Client, catalogClient CatalogClient) ([]Profil
 		return nil, err
 	}
 	if len(profiles) == 0 {
-		fmt.Println("no profiles found")
 		return nil, nil
 	}
 	profileData := make([]ProfileData, 0)


### PR DESCRIPTION
Before:
```
pctl list
no profiles found
NAMESPACE       NAME    SOURCE  AVAILABLE UPDATES
```

After:

```
./pctl list
no profiles installed
```