### PR TITLE
Shifting the artifacts generation to the artifact maker

### DIFF
--- a/cmd/pctl/install.go
+++ b/cmd/pctl/install.go
@@ -175,6 +175,7 @@ func install(c *cli.Context) error {
 		gitRepoName = split[1]
 	}
 	artifactsMaker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
+		ProfileName:      profileName,
 		GitClient:        g,
 		RootDir:          filepath.Join(dir, profileName),
 		GitRepoNamespace: gitRepoNamespace,
@@ -183,13 +184,11 @@ func install(c *cli.Context) error {
 	cfg := catalog.InstallConfig{
 		Clients: catalog.Clients{
 			CatalogClient:  catalogClient,
-			GitClient:      g,
 			ArtifactsMaker: artifactsMaker,
 		},
 		ProfileConfig: catalog.ProfileConfig{
 			CatalogName:   catalogName,
 			ConfigMap:     configValues,
-			GitRepository: gitRepository,
 			Namespace:     namespace,
 			Path:          path,
 			ProfileBranch: branch,
@@ -198,7 +197,6 @@ func install(c *cli.Context) error {
 			URL:           url,
 			Version:       version,
 		},
-		Directory: dir,
 	}
 	return catalog.Install(cfg)
 }

--- a/pkg/catalog/install.go
+++ b/pkg/catalog/install.go
@@ -2,19 +2,11 @@ package catalog
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	"github.com/google/uuid"
 	profilesv1 "github.com/weaveworks/profiles/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
-
-	"github.com/otiai10/copy"
 
 	"github.com/weaveworks/pctl/pkg/git"
 	"github.com/weaveworks/pctl/pkg/profile"
@@ -23,7 +15,6 @@ import (
 // Clients contains a set of clients which are used by install.
 type Clients struct {
 	CatalogClient  CatalogClient
-	GitClient      git.Git // this will be refactor out of here, so it's not Install's responsibility
 	ArtifactsMaker profile.ArtifactsMaker
 }
 
@@ -38,14 +29,12 @@ type ProfileConfig struct {
 	ProfileBranch string
 	URL           string
 	Path          string
-	GitRepository string
 }
 
 // InstallConfig defines parameters for the installation call.
 type InstallConfig struct {
 	Clients
 	ProfileConfig
-	Directory string
 }
 
 // Install using the catalog at catalogURL and a profile matching the provided profileName generates a profile subscription
@@ -75,64 +64,12 @@ func Install(cfg InstallConfig) error {
 			},
 		}
 	}
-	profileRootdir := filepath.Join(cfg.Directory, cfg.ProfileName)
 	artifacts, err := cfg.ArtifactsMaker.MakeArtifacts(subscription)
 	if err != nil {
 		return fmt.Errorf("failed to generate artifacts: %w", err)
 	}
-	artifactsRootDir := filepath.Join(profileRootdir, "artifacts")
-
-	for _, artifact := range artifacts {
-		artifactDir := filepath.Join(artifactsRootDir, artifact.Name)
-		if err = os.MkdirAll(artifactDir, 0755); err != nil {
-			return fmt.Errorf("failed to create directory")
-		}
-		if artifact.RepoURL != "" {
-			if err := getRepositoryLocalArtifacts(cfg, artifact, artifactDir); err != nil {
-				return fmt.Errorf("failed to get package local artifacts: %w", err)
-			}
-		}
-		for _, obj := range artifact.Objects {
-			filename := filepath.Join(artifactDir, fmt.Sprintf("%s.%s", obj.GetObjectKind().GroupVersionKind().Kind, "yaml"))
-			if err := generateOutput(filename, obj); err != nil {
-				return err
-			}
-		}
-	}
-
-	return generateOutput(filepath.Join(profileRootdir, "profile.yaml"), &subscription)
-}
-
-// getRepositoryLocalArtifacts clones all repository local artifacts so they can be copied over to the flux repository.
-func getRepositoryLocalArtifacts(cfg InstallConfig, a profile.Artifact, artifactDir string) error {
-	u := uuid.NewString()[:6]
-	tmp, err := ioutil.TempDir("", "sparse_clone_git_repo_"+u)
-	if err != nil {
-		return fmt.Errorf("failed to create temp folder: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmp); err != nil {
-			fmt.Println("Failed to remove tmp folder: ", tmp)
-		}
-	}()
-	profilePath := a.SparseFolder
-	branch := a.Branch
-	if err := cfg.GitClient.SparseClone(a.RepoURL, branch, tmp, profilePath); err != nil {
-		return fmt.Errorf("failed to sparse clone folder with url: %s; branch: %s; path: %s; with error: %w",
-			a.RepoURL,
-			branch,
-			profilePath,
-			err)
-	}
-	for _, path := range a.PathsToCopy {
-		// nginx/chart/...
-		if strings.Contains(path, string(os.PathSeparator)) {
-			path = filepath.Dir(path)
-		}
-		fullPath := filepath.Join(tmp, profilePath, path)
-		if err := copy.Copy(fullPath, filepath.Join(artifactDir, path)); err != nil {
-			return fmt.Errorf("failed to move folder: %w", err)
-		}
+	if err := cfg.ArtifactsMaker.GenerateArtifactsOutput(artifacts, subscription); err != nil {
+		return fmt.Errorf("failed to generate output for artifacts: %w", err)
 	}
 	return nil
 }
@@ -172,24 +109,6 @@ func getProfileSpec(cfg InstallConfig) (profilesv1.ProfileInstallationSpec, erro
 			Profile: p.Name,
 		},
 	}, nil
-}
-
-func generateOutput(filename string, o runtime.Object) error {
-	e := kjson.NewSerializerWithOptions(kjson.DefaultMetaFactory, nil, nil, kjson.SerializerOptions{Yaml: true, Strict: true})
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer func(f *os.File) {
-		if err := f.Close(); err != nil {
-			fmt.Printf("Failed to properly close file %s\n", f.Name())
-		}
-	}(f)
-	if err := e.Encode(o, f); err != nil {
-		return err
-	}
-	return nil
-
 }
 
 // CreatePullRequest creates a pull request from the current changes.

--- a/pkg/catalog/install.go
+++ b/pkg/catalog/install.go
@@ -64,12 +64,8 @@ func Install(cfg InstallConfig) error {
 			},
 		}
 	}
-	artifacts, err := cfg.ArtifactsMaker.MakeArtifacts(installation)
-	if err != nil {
-		return fmt.Errorf("failed to generate artifacts: %w", err)
-	}
-	if err := cfg.ArtifactsMaker.GenerateOutput(artifacts, installation); err != nil {
-		return fmt.Errorf("failed to generate output for artifacts: %w", err)
+	if err := cfg.ArtifactsMaker.Make(installation); err != nil {
+		return fmt.Errorf("failed to make artifacts: %w", err)
 	}
 	return nil
 }

--- a/pkg/profile/artifact_test.go
+++ b/pkg/profile/artifact_test.go
@@ -683,7 +683,6 @@ var _ = Describe("Profile", func() {
 	})
 	Context("GenerateArtifactsOutput", func() {
 		It("creates files for all artifacts", func() {
-			//profileName := "test-generate"
 			pSub = profilesv1.ProfileInstallation{
 				TypeMeta: profileTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
@@ -737,7 +736,7 @@ var _ = Describe("Profile", func() {
 				fullPath := filepath.Join(dir, "weaveworks-nginx", "nginx", "deployment")
 				err := os.MkdirAll(fullPath, 0755)
 				Expect(err).NotTo(HaveOccurred())
-				return ioutil.WriteFile(filepath.Join(fullPath, "deployment.yaml"), []byte("validYaml:"), 0755)
+				return ioutil.WriteFile(filepath.Join(fullPath, "deployment.yaml"), []byte("validYaml:"), 0644)
 			}
 			err = maker.GenerateArtifactsOutput(artifacts, pSub)
 			Expect(err).NotTo(HaveOccurred())
@@ -758,6 +757,7 @@ var _ = Describe("Profile", func() {
 
 			Expect(hasCorrectFilePerms(profileFile)).To(BeTrue())
 			Expect(hasCorrectFilePerms(artifactFile)).To(BeTrue())
+			Expect(hasCorrectFilePerms(artifactFileDeployment)).To(BeTrue())
 
 			content, err := ioutil.ReadFile(profileFile)
 			Expect(err).NotTo(HaveOccurred())
@@ -794,6 +794,118 @@ spec:
   targetNamespace: default
 status: {}
 `, tempDir)))
+		})
+	})
+
+	When("there is a flat profile repository", func() {
+		It("creates files for all artifacts", func() {
+			pSub = profilesv1.ProfileInstallation{
+				TypeMeta: profileTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      subscriptionName,
+					Namespace: namespace,
+				},
+				Spec: profilesv1.ProfileInstallationSpec{
+					Source: &profilesv1.Source{
+						URL:    "https://github.com/weaveworks/nginx-profile",
+						Branch: "main",
+					},
+				},
+			}
+			p.SetProfileGetter(func(repoURL, branch, path string, gitClient git.Git) (profilesv1.ProfileDefinition, error) {
+				return profilesv1.ProfileDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nginx",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Profile",
+						APIVersion: "packages.weave.works.io/profilesv1",
+					},
+					Spec: profilesv1.ProfileDefinitionSpec{
+						ProfileDescription: profilesv1.ProfileDescription{
+							Name:        "nginx",
+							Description: "foo",
+						},
+						Artifacts: []profilesv1.Artifact{
+							{
+								Name: "bitnami-nginx",
+								Chart: &profilesv1.Chart{
+									URL:     "https://charts.bitnami.com/bitnami",
+									Name:    "nginx",
+									Version: "8.9.1",
+								},
+							},
+						},
+					},
+				}, nil
+			})
+			tempDir, err := ioutil.TempDir("", "catalog-install")
+			Expect(err).NotTo(HaveOccurred())
+			maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
+				ProfileName:      "generate-test",
+				GitClient:        fakeGitClient,
+				RootDir:          tempDir,
+				GitRepoNamespace: gitRepoNamespace,
+				GitRepoName:      gitRepoName,
+			})
+			artifacts, err := maker.MakeArtifacts(pSub)
+			Expect(err).NotTo(HaveOccurred())
+			err = maker.GenerateArtifactsOutput(artifacts, pSub)
+			Expect(err).NotTo(HaveOccurred())
+
+			var files []string
+			err = filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					files = append(files, path)
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			profileFile := filepath.Join(tempDir, "generate-test", "profile.yaml")
+			artifactHelmRelease := filepath.Join(tempDir, "generate-test", "artifacts", "bitnami-nginx", "HelmRelease.yaml")
+			artifactHelmRepository := filepath.Join(tempDir, "generate-test", "artifacts", "bitnami-nginx", "HelmRepository.yaml")
+			Expect(files).To(ConsistOf(artifactHelmRepository, artifactHelmRelease, profileFile))
+
+			Expect(hasCorrectFilePerms(profileFile)).To(BeTrue())
+			Expect(hasCorrectFilePerms(artifactHelmRelease)).To(BeTrue())
+			Expect(hasCorrectFilePerms(artifactHelmRepository)).To(BeTrue())
+
+			content, err := ioutil.ReadFile(profileFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(`apiVersion: weave.works/v1alpha1
+kind: ProfileInstallation
+metadata:
+  creationTimestamp: null
+  name: mySub
+  namespace: default
+spec:
+  source:
+    branch: main
+    url: https://github.com/weaveworks/nginx-profile
+status: {}
+`))
+
+			content, err = ioutil.ReadFile(artifactHelmRelease)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(`apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  creationTimestamp: null
+  name: mySub-nginx-bitnami-nginx
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: nginx
+      sourceRef:
+        kind: HelmRepository
+        name: mySub-nginx-profile-nginx
+        namespace: default
+      version: 8.9.1
+  interval: 0s
+status: {}
+`))
 		})
 	})
 })

--- a/pkg/profile/artifact_test.go
+++ b/pkg/profile/artifact_test.go
@@ -6,13 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/otiai10/copy"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -24,27 +22,21 @@ import (
 )
 
 const (
-	installationName     = "mySub"
-	namespace            = "default"
 	branch               = "main"
-	profileName1         = "profileName"
-	profileName2         = "profileName2"
-	chartName1           = "chartOneArtifactName"
-	chartPath1           = "chart/artifact/path-one"
-	chartName2           = "chartTwoArtifactName"
-	chartPath2           = "chart/artifact/path-two"
-	helmChartName1       = "helmChartArtifactName1"
+	chartName1           = "nginx-server"
+	gitRepoName          = "git-repo-name"
+	gitRepoNamespace     = "git-repo-namespace"
 	helmChartChart1      = "helmChartChartName1"
+	helmChartName1       = "helmChartArtifactName1"
 	helmChartURL1        = "https://org.github.io/chart"
 	helmChartVersion1    = "8.8.1"
-	kustomizeName1       = "kustomizeOneArtifactName"
-	kustomizePath1       = "kustomize/artifact/path-one"
-	profileSubKind       = "ProfileInstallation"
+	installationName     = "mySub"
+	namespace            = "default"
+	profileName1         = "weaveworks-nginx"
+	profileName2         = "bitnami-nginx"
 	profileSubAPIVersion = "weave.works/v1alpha1"
+	profileSubKind       = "ProfileInstallation"
 	profileURL           = "https://github.com/org/repo-name"
-	gitRepoNamespace     = "git-repo-namespace"
-	gitRepoName          = "git-repo-name"
-	rootDir              = "root-dir"
 )
 
 var (
@@ -52,9 +44,6 @@ var (
 		Kind:       profileSubKind,
 		APIVersion: profileSubAPIVersion,
 	}
-
-	gitRepoKind  = sourcev1.GitRepositoryKind
-	helmRepoKind = sourcev1.HelmRepositoryKind
 )
 
 var _ = Describe("Profile", func() {
@@ -65,6 +54,7 @@ var _ = Describe("Profile", func() {
 		pNestedDef    profilesv1.ProfileDefinition
 		pNestedDefURL = "https://github.com/org/repo-name-nested"
 		fakeGitClient *fakegit.FakeGit
+		rootDir       string
 	)
 
 	BeforeEach(func() {
@@ -109,7 +99,7 @@ var _ = Describe("Profile", func() {
 					{
 						Name: chartName1,
 						Chart: &profilesv1.Chart{
-							Path: chartPath1,
+							Path: "nginx/chart",
 						},
 					},
 				},
@@ -133,30 +123,23 @@ var _ = Describe("Profile", func() {
 						Name: profileName2,
 						Profile: &profilesv1.Profile{
 							Source: &profilesv1.Source{
-								URL:    pNestedDefURL,
-								Branch: "main",
-								Path:   profileName2,
+								URL: pNestedDefURL,
+								Tag: "bitnami-nginx/v0.0.1",
 							},
 						},
 					},
 					{
-						Name: chartName2,
-						Chart: &profilesv1.Chart{
-							Path: chartPath2,
-						},
-					},
-					{
-						Name: kustomizeName1,
+						Name: "nginx-deployment",
 						Kustomize: &profilesv1.Kustomize{
-							Path: kustomizePath1,
+							Path: "nginx/deployment",
 						},
 					},
 					{
-						Name: helmChartName1,
+						Name: "dokuwiki",
 						Chart: &profilesv1.Chart{
-							URL:     helmChartURL1,
-							Name:    helmChartChart1,
-							Version: helmChartVersion1,
+							URL:     "https://charts.bitnami.com/bitnami",
+							Name:    "dokuwiki",
+							Version: "11.1.6",
 						},
 					},
 				},
@@ -164,14 +147,23 @@ var _ = Describe("Profile", func() {
 		}
 		fakeGitClient = &fakegit.FakeGit{}
 		p.SetProfileGetter(func(repoURL, branch, path string, gitClient git.Git) (profilesv1.ProfileDefinition, error) {
-			if profileURL == repoURL {
+			if path == "weaveworks-nginx" {
 				return pDef, nil
 			}
 			return pNestedDef, nil
 		})
+		fakeGitClient.SparseCloneStub = func(url string, branch string, dir string, p string) error {
+			from := filepath.Join("testdata", "simple_with_nested", p)
+			err := copy.Copy(from, filepath.Join(dir, p))
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		}
+		var err error
+		rootDir, err = ioutil.TempDir("", "test_make_artifacts")
+		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("MakeArtifacts", func() {
+	Context("Make", func() {
 		It("generates the artifacts", func() {
 			maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
 				GitClient:        fakeGitClient,
@@ -179,230 +171,176 @@ var _ = Describe("Profile", func() {
 				GitRepoNamespace: gitRepoNamespace,
 				GitRepoName:      gitRepoName,
 			})
-			artifacts, err := maker.MakeArtifacts(pSub)
+			err := maker.Make(pSub)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(artifacts).To(HaveLen(4))
+			files := make(map[string]string)
+			err = filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+				if !info.IsDir() {
+					files[fmt.Sprintf("%s/%s", filepath.Base(filepath.Dir(path)), filepath.Base(path))] = path
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			consistsOf := []string{
+				filepath.Join(rootDir, "profile-installation.yaml"),
+				filepath.Join(rootDir, "artifacts", "nginx-deployment", "Kustomization.yaml"),
+				filepath.Join(rootDir, "artifacts", "nginx-deployment", "nginx", "deployment", "deployment.yaml"),
+				filepath.Join(rootDir, "artifacts", "bitnami-nginx", "nginx-server", "HelmRelease.yaml"),
+				filepath.Join(rootDir, "artifacts", "bitnami-nginx", "nginx-server", "nginx", "chart", "Chart.yaml"),
+				filepath.Join(rootDir, "artifacts", "dokuwiki", "HelmRelease.yaml"),
+				filepath.Join(rootDir, "artifacts", "dokuwiki", "HelmRepository.yaml"),
+			}
+			Expect(files).To(ConsistOf(consistsOf))
+
+			By("inspecting the profile-installation.yaml", func() {
+				parent := filepath.Base(rootDir)
+				content, err := ioutil.ReadFile(files[filepath.Join(parent, "profile-installation.yaml")])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(`apiVersion: weave.works/v1alpha1
+kind: ProfileInstallation
+metadata:
+  creationTimestamp: null
+  name: mySub
+  namespace: default
+spec:
+  source:
+    branch: main
+    path: weaveworks-nginx
+    url: https://github.com/org/repo-name
+  values:
+    replicaCount: 3
+    service:
+      port: 8081
+  valuesFrom:
+  - kind: Secret
+    name: nginx-values
+    optional: true
+status: {}
+`))
+			})
 
 			By("generating the nested profile artifact", func() {
-				nestedProfileArtifact := artifacts[0]
-				Expect(nestedProfileArtifact.Name).To(Equal(filepath.Join(profileName2, chartName1)))
+				content, err := ioutil.ReadFile(files["nginx-server/HelmRelease.yaml"])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  creationTimestamp: null
+  name: mySub-bitnami-nginx-nginx-server
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: %s/artifacts/bitnami-nginx/nginx-server/nginx/chart
+      sourceRef:
+        kind: GitRepository
+        name: git-repo-name
+        namespace: git-repo-namespace
+  interval: 0s
+  values:
+    replicaCount: 3
+    service:
+      port: 8081
+  valuesFrom:
+  - kind: Secret
+    name: nginx-values
+    optional: true
+status: {}
+`, rootDir)))
 
-				objects := nestedProfileArtifact.Objects
-				Expect(objects).To(HaveLen(1))
-
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName2, chartName1)
-				helmRelease := objects[0].(*helmv2.HelmRelease)
-
-				Expect(helmRelease.Name).To(Equal(helmReleaseName))
-				Expect(helmRelease.Spec.Chart.Spec.Chart).To(Equal("root-dir/artifacts/profileName2/chartOneArtifactName/chart/artifact/path-one"))
-				Expect(helmRelease.Spec.Chart.Spec.SourceRef).To(Equal(
-					helmv2.CrossNamespaceObjectReference{
-						Kind:      gitRepoKind,
-						Name:      gitRepoName,
-						Namespace: gitRepoNamespace,
-					},
-				))
-				Expect(helmRelease.GetValues()).To(Equal(map[string]interface{}{
-					"replicaCount": float64(3),
-					"service": map[string]interface{}{
-						"port": float64(8081),
-					},
-				}))
-				Expect(helmRelease.Spec.ValuesFrom).To(Equal([]helmv2.ValuesReference{
-					{
-						Name:     "nginx-values",
-						Kind:     "Secret",
-						Optional: true,
-					},
-				}))
 			})
 
-			By("generating the path based helm release artifact", func() {
-				pathBasedHelmArtifact := artifacts[1]
-				Expect(pathBasedHelmArtifact.Name).To(Equal(chartName2))
-
-				objects := pathBasedHelmArtifact.Objects
-
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, chartName2)
-				helmRelease := objects[0].(*helmv2.HelmRelease)
-				Expect(helmRelease.Name).To(Equal(helmReleaseName))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(helmRelease.Spec.Chart.Spec.Chart).To(Equal("root-dir/artifacts/chartTwoArtifactName/chart/artifact/path-two"))
-				Expect(helmRelease.Spec.Chart.Spec.SourceRef).To(Equal(
-					helmv2.CrossNamespaceObjectReference{
-						Kind:      gitRepoKind,
-						Name:      gitRepoName,
-						Namespace: gitRepoNamespace,
-					},
-				))
-				Expect(helmRelease.GetValues()).To(Equal(map[string]interface{}{
-					"replicaCount": float64(3),
-					"service": map[string]interface{}{
-						"port": float64(8081),
-					},
-				}))
-				Expect(helmRelease.Spec.ValuesFrom).To(Equal([]helmv2.ValuesReference{
-					{
-						Name:     "nginx-values",
-						Kind:     "Secret",
-						Optional: true,
-					},
-				}))
+			By("generating the path based kustomization artifact", func() {
+				content, err := ioutil.ReadFile(files["nginx-deployment/Kustomization.yaml"])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  creationTimestamp: null
+  name: mySub-weaveworks-nginx-nginx-deployment
+  namespace: default
+spec:
+  interval: 5m0s
+  path: %s/artifacts/nginx-deployment/nginx/deployment
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: git-repo-name
+    namespace: git-repo-namespace
+  targetNamespace: default
+status: {}
+`, rootDir)))
 			})
 
-			By("generating the kustomize artifact", func() {
-				kustomizeArtifact := artifacts[2]
-				Expect(kustomizeArtifact.Name).To(Equal(kustomizeName1))
-
-				objects := kustomizeArtifact.Objects
-
-				kustomizeName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, kustomizeName1)
-				kustomize := objects[0].(*kustomizev1.Kustomization)
-				Expect(kustomize.Name).To(Equal(kustomizeName))
-				Expect(kustomize.Spec.Path).To(Equal("root-dir/artifacts/kustomizeOneArtifactName/kustomize/artifact/path-one"))
-				Expect(kustomize.Spec.TargetNamespace).To(Equal(namespace))
-				Expect(kustomize.Spec.Prune).To(BeTrue())
-				Expect(kustomize.Spec.Interval).To(Equal(metav1.Duration{Duration: time.Minute * 5}))
-				Expect(kustomize.Spec.SourceRef).To(Equal(
-					kustomizev1.CrossNamespaceSourceReference{
-						Kind:      gitRepoKind,
-						Name:      gitRepoName,
-						Namespace: gitRepoNamespace,
-					},
-				))
-			})
-
-			By("generating the repository based helm artifact", func() {
-				helmArtifact := artifacts[3]
-				Expect(helmArtifact.Name).To(Equal(helmChartName1))
-
-				objects := helmArtifact.Objects
-				Expect(objects).To(HaveLen(2))
-
-				helmRefName := fmt.Sprintf("%s-%s-%s", installationName, "repo-name", helmChartChart1)
-				helmRepo := objects[1].(*sourcev1.HelmRepository)
-				Expect(helmRepo.Name).To(Equal(helmRefName))
-				Expect(helmRepo.Spec.URL).To(Equal(helmChartURL1))
-
-				helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, helmChartName1)
-				helmRelease := objects[0].(*helmv2.HelmRelease)
-				Expect(helmRelease.Name).To(Equal(helmReleaseName))
-				Expect(helmRelease.Spec.Chart.Spec.Chart).To(Equal(helmChartChart1))
-				Expect(helmRelease.Spec.Chart.Spec.Version).To(Equal(helmChartVersion1))
-				Expect(helmRelease.Spec.Chart.Spec.SourceRef).To(Equal(
-					helmv2.CrossNamespaceObjectReference{
-						Kind:      helmRepoKind,
-						Name:      helmRefName,
-						Namespace: namespace,
-					},
-				))
-				Expect(helmRelease.GetValues()).To(Equal(map[string]interface{}{
-					"replicaCount": float64(3),
-					"service": map[string]interface{}{
-						"port": float64(8081),
-					},
-				}))
-				Expect(helmRelease.Spec.ValuesFrom).To(Equal([]helmv2.ValuesReference{
-					{
-						Name:     "nginx-values",
-						Kind:     "Secret",
-						Optional: true,
-					},
-				}))
-			})
-		})
-
-		When("the branch name for a git repository is not domain compatible", func() {
-			It("will sanitise it", func() {
-				pSub = profilesv1.ProfileInstallation{
-					TypeMeta: profileTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      installationName,
-						Namespace: namespace,
-					},
-					Spec: profilesv1.ProfileInstallationSpec{
-						Source: &profilesv1.Source{
-							URL:    profileURL,
-							Branch: "not_domain_compatible",
-						},
-					},
-				}
-				maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
-					GitClient:        fakeGitClient,
-					RootDir:          rootDir,
-					GitRepoNamespace: gitRepoNamespace,
-					GitRepoName:      gitRepoName,
-				})
-				artifacts, err := maker.MakeArtifacts(pSub)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(artifacts).To(HaveLen(4))
-
-				By("generating the path based helm release artifact", func() {
-					pathBasedHelmArtifact := artifacts[1]
-					Expect(pathBasedHelmArtifact.Name).To(Equal(chartName2))
-
-					objects := pathBasedHelmArtifact.Objects
-
-					helmReleaseName := fmt.Sprintf("%s-%s-%s", installationName, profileName1, chartName2)
-					helmRelease := objects[0].(*helmv2.HelmRelease)
-					Expect(helmRelease.Name).To(Equal(helmReleaseName))
-					Expect(err).NotTo(HaveOccurred())
-					Expect(helmRelease.Spec.Chart.Spec.Chart).To(Equal("root-dir/artifacts/chartTwoArtifactName/chart/artifact/path-two"))
-					Expect(helmRelease.Spec.Chart.Spec.SourceRef).To(Equal(
-						helmv2.CrossNamespaceObjectReference{
-							Kind:      gitRepoKind,
-							Name:      gitRepoName,
-							Namespace: gitRepoNamespace,
-						},
-					))
-				})
+			By("generating a remote helm chart", func() {
+				content, err := ioutil.ReadFile(files["dokuwiki/HelmRelease.yaml"])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(`apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  creationTimestamp: null
+  name: mySub-weaveworks-nginx-dokuwiki
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: dokuwiki
+      sourceRef:
+        kind: HelmRepository
+        name: mySub-repo-name-dokuwiki
+        namespace: default
+      version: 11.1.6
+  interval: 0s
+  values:
+    replicaCount: 3
+    service:
+      port: 8081
+  valuesFrom:
+  - kind: Secret
+    name: nginx-values
+    optional: true
+status: {}
+`))
+				content, err = ioutil.ReadFile(files["dokuwiki/HelmRepository.yaml"])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(Equal(`apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  creationTimestamp: null
+  name: mySub-repo-name-dokuwiki
+  namespace: default
+spec:
+  interval: 0s
+  url: https://charts.bitnami.com/bitnami
+status: {}
+`))
 			})
 		})
 
 		When("the git repository name is not defined", func() {
 			It("errors out", func() {
-				pSub = profilesv1.ProfileInstallation{
-					TypeMeta: profileTypeMeta,
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      installationName,
-						Namespace: namespace,
-					},
-					Spec: profilesv1.ProfileInstallationSpec{
-						Source: &profilesv1.Source{
-							URL:    profileURL,
-							Branch: branch,
-						},
-					},
-				}
 				maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
 					GitClient: fakeGitClient,
 					RootDir:   rootDir,
 				})
-				artifacts, err := maker.MakeArtifacts(pSub)
-				Expect(err).To(MatchError("failed to generate resources for nested profile \"profileName2\": in case of local resources, the flux gitrepository object's details must be provided"))
-				Expect(artifacts).To(BeEmpty())
+				err := maker.Make(pSub)
+				Expect(err).To(MatchError("failed to generate resources for nested profile \"bitnami-nginx\": in case of local resources, the flux gitrepository object's details must be provided"))
 			})
 		})
 
 		When("fetching the nested profile definition fails", func() {
-			BeforeEach(func() {
-				p.SetProfileGetter(func(repoURL, branch, path string, gitClient git.Git) (profilesv1.ProfileDefinition, error) {
-					if repoURL == profileURL {
-						return pDef, nil
-					}
-					return pNestedDef, fmt.Errorf("foo")
-				})
-			})
-
 			It("returns an error", func() {
+				p.SetProfileGetter(func(repoURL, branch, path string, gitClient git.Git) (profilesv1.ProfileDefinition, error) {
+					return profilesv1.ProfileDefinition{}, fmt.Errorf("foo")
+				})
 				maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
 					GitClient:        fakeGitClient,
 					RootDir:          rootDir,
 					GitRepoNamespace: gitRepoNamespace,
 					GitRepoName:      gitRepoName,
 				})
-				_, err := maker.MakeArtifacts(pSub)
-				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("failed to get profile definition %s on branch %s: foo", pNestedDefURL, branch))))
+				err := maker.Make(pSub)
+				Expect(err).To(MatchError(ContainSubstring("failed to get profile definition: foo")))
 			})
 		})
 
@@ -419,11 +357,10 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
+					err := maker.Make(pSub)
 					Expect(err).To(MatchError(ContainSubstring("no artifact set")))
 				})
 			})
-
 			When("the nested profile is invalid", func() {
 				BeforeEach(func() {
 					pNestedDef.Spec.Artifacts[0] = profilesv1.Artifact{}
@@ -436,8 +373,8 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
-					Expect(err).To(MatchError(ContainSubstring("failed to generate resources for nested profile \"profileName2\":")))
+					err := maker.Make(pSub)
+					Expect(err).To(MatchError(ContainSubstring("failed to generate resources for nested profile \"bitnami-nginx\":")))
 				})
 			})
 			When("helmRepository and path", func() {
@@ -476,11 +413,10 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
+					err := maker.Make(pSub)
 					Expect(err).To(MatchError(ContainSubstring("validation failed for artifact helmChartArtifactName1: expected exactly one, got both: chart.path, chart.url")))
 				})
 			})
-
 			When("chart and kustomize", func() {
 				BeforeEach(func() {
 					pDef = profilesv1.ProfileDefinition{
@@ -519,11 +455,10 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
+					err := maker.Make(pSub)
 					Expect(err).To(MatchError(ContainSubstring("validation failed for artifact helmChartArtifactName1: expected exactly one, got both: chart, kustomize")))
 				})
 			})
-
 			When("profile and kustomize", func() {
 				BeforeEach(func() {
 					pDef = profilesv1.ProfileDefinition{
@@ -563,7 +498,7 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
+					err := maker.Make(pSub)
 					Expect(err).To(MatchError(ContainSubstring("validation failed for artifact helmChartArtifactName1: expected exactly one, got both: kustomize, profile")))
 				})
 			})
@@ -609,7 +544,7 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
+					err := maker.Make(pSub)
 					Expect(err).To(MatchError(ContainSubstring("validation failed for artifact helmChartArtifactName1: expected exactly one, got both: chart, profile")))
 				})
 			})
@@ -675,129 +610,13 @@ var _ = Describe("Profile", func() {
 						GitRepoNamespace: gitRepoNamespace,
 						GitRepoName:      gitRepoName,
 					})
-					_, err := maker.MakeArtifacts(pSub)
-					Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("recursive artifact detected: profile %s on branch %s contains an artifact that points recursively back at itself", pNestedDefURL, branch))))
+					err := maker.Make(pSub)
+					Expect(err).To(MatchError(ContainSubstring("failed to generate resources for nested profile \"bitnami-nginx\": failed to generate resources for nested profile \"bitnami-nginx/recursive\": failed to generate resources for nested profile \"bitnami-nginx/recursive/recursive\": recursive artifact detected: profile https://github.com/org/repo-name-nested on branch")))
 				})
 			})
 		})
 	})
-	Context("GenerateOutput", func() {
-		It("creates files for all artifacts", func() {
-			pSub = profilesv1.ProfileInstallation{
-				TypeMeta: profileTypeMeta,
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      installationName,
-					Namespace: namespace,
-				},
-				Spec: profilesv1.ProfileInstallationSpec{
-					Source: &profilesv1.Source{
-						URL:    "https://github.com/weaveworks/profiles-examples",
-						Branch: "main",
-						Path:   "weaveworks-nginx",
-					},
-				},
-			}
-			p.SetProfileGetter(func(repoURL, branch, path string, gitClient git.Git) (profilesv1.ProfileDefinition, error) {
-				return profilesv1.ProfileDefinition{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "weaveworks-nginx",
-					},
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Profile",
-						APIVersion: "packages.weave.works.io/profilesv1",
-					},
-					Spec: profilesv1.ProfileDefinitionSpec{
-						ProfileDescription: profilesv1.ProfileDescription{
-							Description: "foo",
-						},
-						Artifacts: []profilesv1.Artifact{
-							{
-								Name: "nginx-deployment",
-								Kustomize: &profilesv1.Kustomize{
-									Path: "nginx/deployment",
-								},
-							},
-						},
-					},
-				}, nil
-			})
-			tempDir, err := ioutil.TempDir("", "catalog-install")
-			Expect(err).NotTo(HaveOccurred())
-			maker := profile.NewProfilesArtifactsMaker(profile.MakerConfig{
-				ProfileName:      "generate-test",
-				GitClient:        fakeGitClient,
-				RootDir:          tempDir,
-				GitRepoNamespace: gitRepoNamespace,
-				GitRepoName:      gitRepoName,
-			})
-			artifacts, err := maker.MakeArtifacts(pSub)
-			Expect(err).NotTo(HaveOccurred())
-			fakeGitClient.SparseCloneStub = func(url string, branch string, dir string, p string) error {
-				fullPath := filepath.Join(dir, "weaveworks-nginx", "nginx", "deployment")
-				err := os.MkdirAll(fullPath, 0755)
-				Expect(err).NotTo(HaveOccurred())
-				return ioutil.WriteFile(filepath.Join(fullPath, "deployment.yaml"), []byte("validYaml:"), 0644)
-			}
-			err = maker.GenerateOutput(artifacts, pSub)
-			Expect(err).NotTo(HaveOccurred())
-
-			var files []string
-			err = filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
-				if !info.IsDir() {
-					files = append(files, path)
-				}
-				return nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			profileFile := filepath.Join(tempDir, "generate-test", "profile.yaml")
-			artifactFile := filepath.Join(tempDir, "generate-test", "artifacts", "nginx-deployment", "Kustomization.yaml")
-			artifactFileDeployment := filepath.Join(tempDir, "generate-test", "artifacts", "nginx-deployment", "nginx", "deployment", "deployment.yaml")
-			Expect(files).To(ConsistOf(artifactFile, artifactFileDeployment, profileFile))
-
-			Expect(hasCorrectFilePerms(profileFile)).To(BeTrue())
-			Expect(hasCorrectFilePerms(artifactFile)).To(BeTrue())
-			Expect(hasCorrectFilePerms(artifactFileDeployment)).To(BeTrue())
-
-			content, err := ioutil.ReadFile(profileFile)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal(`apiVersion: weave.works/v1alpha1
-kind: ProfileInstallation
-metadata:
-  creationTimestamp: null
-  name: mySub
-  namespace: default
-spec:
-  source:
-    branch: main
-    path: weaveworks-nginx
-    url: https://github.com/weaveworks/profiles-examples
-status: {}
-`))
-
-			content, err = ioutil.ReadFile(artifactFile)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
-kind: Kustomization
-metadata:
-  creationTimestamp: null
-  name: mySub-weaveworks-nginx-nginx-deployment
-  namespace: default
-spec:
-  interval: 5m0s
-  path: %s/artifacts/nginx-deployment/nginx/deployment
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: git-repo-name
-    namespace: git-repo-namespace
-  targetNamespace: default
-status: {}
-`, tempDir)))
-		})
-	})
-
-	When("there is a flat profile repository", func() {
+	When("there is a single profile repository", func() {
 		It("creates files for all artifacts", func() {
 			pSub = profilesv1.ProfileInstallation{
 				TypeMeta: profileTypeMeta,
@@ -848,9 +667,7 @@ status: {}
 				GitRepoNamespace: gitRepoNamespace,
 				GitRepoName:      gitRepoName,
 			})
-			artifacts, err := maker.MakeArtifacts(pSub)
-			Expect(err).NotTo(HaveOccurred())
-			err = maker.GenerateOutput(artifacts, pSub)
+			err = maker.Make(pSub)
 			Expect(err).NotTo(HaveOccurred())
 
 			var files []string
@@ -862,7 +679,7 @@ status: {}
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			profileFile := filepath.Join(tempDir, "generate-test", "profile.yaml")
+			profileFile := filepath.Join(tempDir, "generate-test", "profile-installation.yaml")
 			artifactHelmRelease := filepath.Join(tempDir, "generate-test", "artifacts", "bitnami-nginx", "HelmRelease.yaml")
 			artifactHelmRepository := filepath.Join(tempDir, "generate-test", "artifacts", "bitnami-nginx", "HelmRepository.yaml")
 			Expect(files).To(ConsistOf(artifactHelmRepository, artifactHelmRelease, profileFile))

--- a/pkg/profile/fakes/artifacts_maker.go
+++ b/pkg/profile/fakes/artifacts_maker.go
@@ -9,6 +9,18 @@ import (
 )
 
 type FakeArtifactsMaker struct {
+	GenerateArtifactsOutputStub        func([]profile.Artifact, v1alpha1.ProfileInstallation) error
+	generateArtifactsOutputMutex       sync.RWMutex
+	generateArtifactsOutputArgsForCall []struct {
+		arg1 []profile.Artifact
+		arg2 v1alpha1.ProfileInstallation
+	}
+	generateArtifactsOutputReturns struct {
+		result1 error
+	}
+	generateArtifactsOutputReturnsOnCall map[int]struct {
+		result1 error
+	}
 	MakeArtifactsStub        func(v1alpha1.ProfileInstallation) ([]profile.Artifact, error)
 	makeArtifactsMutex       sync.RWMutex
 	makeArtifactsArgsForCall []struct {
@@ -24,6 +36,73 @@ type FakeArtifactsMaker struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutput(arg1 []profile.Artifact, arg2 v1alpha1.ProfileInstallation) error {
+	var arg1Copy []profile.Artifact
+	if arg1 != nil {
+		arg1Copy = make([]profile.Artifact, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.generateArtifactsOutputMutex.Lock()
+	ret, specificReturn := fake.generateArtifactsOutputReturnsOnCall[len(fake.generateArtifactsOutputArgsForCall)]
+	fake.generateArtifactsOutputArgsForCall = append(fake.generateArtifactsOutputArgsForCall, struct {
+		arg1 []profile.Artifact
+		arg2 v1alpha1.ProfileInstallation
+	}{arg1Copy, arg2})
+	stub := fake.GenerateArtifactsOutputStub
+	fakeReturns := fake.generateArtifactsOutputReturns
+	fake.recordInvocation("GenerateArtifactsOutput", []interface{}{arg1Copy, arg2})
+	fake.generateArtifactsOutputMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutputCallCount() int {
+	fake.generateArtifactsOutputMutex.RLock()
+	defer fake.generateArtifactsOutputMutex.RUnlock()
+	return len(fake.generateArtifactsOutputArgsForCall)
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutputCalls(stub func([]profile.Artifact, v1alpha1.ProfileInstallation) error) {
+	fake.generateArtifactsOutputMutex.Lock()
+	defer fake.generateArtifactsOutputMutex.Unlock()
+	fake.GenerateArtifactsOutputStub = stub
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutputArgsForCall(i int) ([]profile.Artifact, v1alpha1.ProfileInstallation) {
+	fake.generateArtifactsOutputMutex.RLock()
+	defer fake.generateArtifactsOutputMutex.RUnlock()
+	argsForCall := fake.generateArtifactsOutputArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutputReturns(result1 error) {
+	fake.generateArtifactsOutputMutex.Lock()
+	defer fake.generateArtifactsOutputMutex.Unlock()
+	fake.GenerateArtifactsOutputStub = nil
+	fake.generateArtifactsOutputReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeArtifactsMaker) GenerateArtifactsOutputReturnsOnCall(i int, result1 error) {
+	fake.generateArtifactsOutputMutex.Lock()
+	defer fake.generateArtifactsOutputMutex.Unlock()
+	fake.GenerateArtifactsOutputStub = nil
+	if fake.generateArtifactsOutputReturnsOnCall == nil {
+		fake.generateArtifactsOutputReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.generateArtifactsOutputReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeArtifactsMaker) MakeArtifacts(arg1 v1alpha1.ProfileInstallation) ([]profile.Artifact, error) {
@@ -93,6 +172,8 @@ func (fake *FakeArtifactsMaker) MakeArtifactsReturnsOnCall(i int, result1 []prof
 func (fake *FakeArtifactsMaker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.generateArtifactsOutputMutex.RLock()
+	defer fake.generateArtifactsOutputMutex.RUnlock()
 	fake.makeArtifactsMutex.RLock()
 	defer fake.makeArtifactsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/profile/fakes/artifacts_maker.go
+++ b/pkg/profile/fakes/artifacts_maker.go
@@ -9,53 +9,33 @@ import (
 )
 
 type FakeArtifactsMaker struct {
-	GenerateArtifactsOutputStub        func([]profile.Artifact, v1alpha1.ProfileInstallation) error
-	generateArtifactsOutputMutex       sync.RWMutex
-	generateArtifactsOutputArgsForCall []struct {
-		arg1 []profile.Artifact
-		arg2 v1alpha1.ProfileInstallation
-	}
-	generateArtifactsOutputReturns struct {
-		result1 error
-	}
-	generateArtifactsOutputReturnsOnCall map[int]struct {
-		result1 error
-	}
-	MakeArtifactsStub        func(v1alpha1.ProfileInstallation) ([]profile.Artifact, error)
-	makeArtifactsMutex       sync.RWMutex
-	makeArtifactsArgsForCall []struct {
+	MakeStub        func(v1alpha1.ProfileInstallation) error
+	makeMutex       sync.RWMutex
+	makeArgsForCall []struct {
 		arg1 v1alpha1.ProfileInstallation
 	}
-	makeArtifactsReturns struct {
-		result1 []profile.Artifact
-		result2 error
+	makeReturns struct {
+		result1 error
 	}
-	makeArtifactsReturnsOnCall map[int]struct {
-		result1 []profile.Artifact
-		result2 error
+	makeReturnsOnCall map[int]struct {
+		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeArtifactsMaker) GenerateOutput(arg1 []profile.Artifact, arg2 v1alpha1.ProfileInstallation) error {
-	var arg1Copy []profile.Artifact
-	if arg1 != nil {
-		arg1Copy = make([]profile.Artifact, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.generateArtifactsOutputMutex.Lock()
-	ret, specificReturn := fake.generateArtifactsOutputReturnsOnCall[len(fake.generateArtifactsOutputArgsForCall)]
-	fake.generateArtifactsOutputArgsForCall = append(fake.generateArtifactsOutputArgsForCall, struct {
-		arg1 []profile.Artifact
-		arg2 v1alpha1.ProfileInstallation
-	}{arg1Copy, arg2})
-	stub := fake.GenerateArtifactsOutputStub
-	fakeReturns := fake.generateArtifactsOutputReturns
-	fake.recordInvocation("GenerateOutput", []interface{}{arg1Copy, arg2})
-	fake.generateArtifactsOutputMutex.Unlock()
+func (fake *FakeArtifactsMaker) Make(arg1 v1alpha1.ProfileInstallation) error {
+	fake.makeMutex.Lock()
+	ret, specificReturn := fake.makeReturnsOnCall[len(fake.makeArgsForCall)]
+	fake.makeArgsForCall = append(fake.makeArgsForCall, struct {
+		arg1 v1alpha1.ProfileInstallation
+	}{arg1})
+	stub := fake.MakeStub
+	fakeReturns := fake.makeReturns
+	fake.recordInvocation("Make", []interface{}{arg1})
+	fake.makeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -63,119 +43,53 @@ func (fake *FakeArtifactsMaker) GenerateOutput(arg1 []profile.Artifact, arg2 v1a
 	return fakeReturns.result1
 }
 
-func (fake *FakeArtifactsMaker) GenerateArtifactsOutputCallCount() int {
-	fake.generateArtifactsOutputMutex.RLock()
-	defer fake.generateArtifactsOutputMutex.RUnlock()
-	return len(fake.generateArtifactsOutputArgsForCall)
+func (fake *FakeArtifactsMaker) MakeCallCount() int {
+	fake.makeMutex.RLock()
+	defer fake.makeMutex.RUnlock()
+	return len(fake.makeArgsForCall)
 }
 
-func (fake *FakeArtifactsMaker) GenerateArtifactsOutputCalls(stub func([]profile.Artifact, v1alpha1.ProfileInstallation) error) {
-	fake.generateArtifactsOutputMutex.Lock()
-	defer fake.generateArtifactsOutputMutex.Unlock()
-	fake.GenerateArtifactsOutputStub = stub
+func (fake *FakeArtifactsMaker) MakeCalls(stub func(v1alpha1.ProfileInstallation) error) {
+	fake.makeMutex.Lock()
+	defer fake.makeMutex.Unlock()
+	fake.MakeStub = stub
 }
 
-func (fake *FakeArtifactsMaker) GenerateArtifactsOutputArgsForCall(i int) ([]profile.Artifact, v1alpha1.ProfileInstallation) {
-	fake.generateArtifactsOutputMutex.RLock()
-	defer fake.generateArtifactsOutputMutex.RUnlock()
-	argsForCall := fake.generateArtifactsOutputArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeArtifactsMaker) GenerateArtifactsOutputReturns(result1 error) {
-	fake.generateArtifactsOutputMutex.Lock()
-	defer fake.generateArtifactsOutputMutex.Unlock()
-	fake.GenerateArtifactsOutputStub = nil
-	fake.generateArtifactsOutputReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeArtifactsMaker) GenerateArtifactsOutputReturnsOnCall(i int, result1 error) {
-	fake.generateArtifactsOutputMutex.Lock()
-	defer fake.generateArtifactsOutputMutex.Unlock()
-	fake.GenerateArtifactsOutputStub = nil
-	if fake.generateArtifactsOutputReturnsOnCall == nil {
-		fake.generateArtifactsOutputReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.generateArtifactsOutputReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeArtifactsMaker) MakeArtifacts(arg1 v1alpha1.ProfileInstallation) ([]profile.Artifact, error) {
-	fake.makeArtifactsMutex.Lock()
-	ret, specificReturn := fake.makeArtifactsReturnsOnCall[len(fake.makeArtifactsArgsForCall)]
-	fake.makeArtifactsArgsForCall = append(fake.makeArtifactsArgsForCall, struct {
-		arg1 v1alpha1.ProfileInstallation
-	}{arg1})
-	stub := fake.MakeArtifactsStub
-	fakeReturns := fake.makeArtifactsReturns
-	fake.recordInvocation("MakeArtifacts", []interface{}{arg1})
-	fake.makeArtifactsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeArtifactsMaker) MakeArtifactsCallCount() int {
-	fake.makeArtifactsMutex.RLock()
-	defer fake.makeArtifactsMutex.RUnlock()
-	return len(fake.makeArtifactsArgsForCall)
-}
-
-func (fake *FakeArtifactsMaker) MakeArtifactsCalls(stub func(v1alpha1.ProfileInstallation) ([]profile.Artifact, error)) {
-	fake.makeArtifactsMutex.Lock()
-	defer fake.makeArtifactsMutex.Unlock()
-	fake.MakeArtifactsStub = stub
-}
-
-func (fake *FakeArtifactsMaker) MakeArtifactsArgsForCall(i int) v1alpha1.ProfileInstallation {
-	fake.makeArtifactsMutex.RLock()
-	defer fake.makeArtifactsMutex.RUnlock()
-	argsForCall := fake.makeArtifactsArgsForCall[i]
+func (fake *FakeArtifactsMaker) MakeArgsForCall(i int) v1alpha1.ProfileInstallation {
+	fake.makeMutex.RLock()
+	defer fake.makeMutex.RUnlock()
+	argsForCall := fake.makeArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeArtifactsMaker) MakeArtifactsReturns(result1 []profile.Artifact, result2 error) {
-	fake.makeArtifactsMutex.Lock()
-	defer fake.makeArtifactsMutex.Unlock()
-	fake.MakeArtifactsStub = nil
-	fake.makeArtifactsReturns = struct {
-		result1 []profile.Artifact
-		result2 error
-	}{result1, result2}
+func (fake *FakeArtifactsMaker) MakeReturns(result1 error) {
+	fake.makeMutex.Lock()
+	defer fake.makeMutex.Unlock()
+	fake.MakeStub = nil
+	fake.makeReturns = struct {
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeArtifactsMaker) MakeArtifactsReturnsOnCall(i int, result1 []profile.Artifact, result2 error) {
-	fake.makeArtifactsMutex.Lock()
-	defer fake.makeArtifactsMutex.Unlock()
-	fake.MakeArtifactsStub = nil
-	if fake.makeArtifactsReturnsOnCall == nil {
-		fake.makeArtifactsReturnsOnCall = make(map[int]struct {
-			result1 []profile.Artifact
-			result2 error
+func (fake *FakeArtifactsMaker) MakeReturnsOnCall(i int, result1 error) {
+	fake.makeMutex.Lock()
+	defer fake.makeMutex.Unlock()
+	fake.MakeStub = nil
+	if fake.makeReturnsOnCall == nil {
+		fake.makeReturnsOnCall = make(map[int]struct {
+			result1 error
 		})
 	}
-	fake.makeArtifactsReturnsOnCall[i] = struct {
-		result1 []profile.Artifact
-		result2 error
-	}{result1, result2}
+	fake.makeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeArtifactsMaker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.generateArtifactsOutputMutex.RLock()
-	defer fake.generateArtifactsOutputMutex.RUnlock()
-	fake.makeArtifactsMutex.RLock()
-	defer fake.makeArtifactsMutex.RUnlock()
+	fake.makeMutex.RLock()
+	defer fake.makeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/profile/testdata/simple_with_nested/bitnami-nginx/nginx/chart/Chart.yaml
+++ b/pkg/profile/testdata/simple_with_nested/bitnami-nginx/nginx/chart/Chart.yaml
@@ -1,0 +1,28 @@
+annotations:
+  category: Infrastructure
+apiVersion: v2
+appVersion: 1.19.8
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+description: Chart for the nginx server
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/nginx
+icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
+keywords:
+  - nginx
+  - http
+  - web
+  - www
+  - reverse proxy
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: nginx
+sources:
+  - https://github.com/bitnami/bitnami-docker-nginx
+  - http://www.nginx.org
+version: 8.7.1

--- a/pkg/profile/testdata/simple_with_nested/bitnami-nginx/profiles.yaml
+++ b/pkg/profile/testdata/simple_with_nested/bitnami-nginx/profiles.yaml
@@ -1,0 +1,14 @@
+apiVersion: weave.works/v1alpha1
+kind: ProfileDefinition
+metadata:
+  name: bitnami-nginx
+spec:
+  name: bitnami-nginx
+  description: Profile for deploying local nginx chart
+  maintainer: weaveworks
+  prerequisites:
+    - "kubernetes 1.19"
+  artifacts:
+    - name: nginx-server
+      chart:
+        path: nginx/chart

--- a/pkg/profile/testdata/simple_with_nested/weaveworks-nginx/nginx/deployment/deployment.yaml
+++ b/pkg/profile/testdata/simple_with_nested/weaveworks-nginx/nginx/deployment/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/pkg/profile/testdata/simple_with_nested/weaveworks-nginx/profiles.yaml
+++ b/pkg/profile/testdata/simple_with_nested/weaveworks-nginx/profiles.yaml
@@ -1,0 +1,24 @@
+apiVersion: weave.works/v1alpha1
+kind: ProfileDefinition
+metadata:
+  name: weaveworks-nginx
+spec:
+  name: weaveworks-nginx
+  description: Profile for deploying nginx
+  maintainer: weaveworks
+  prerequisites:
+    - "kubernetes 1.19"
+  artifacts:
+    - name: nested-profile
+      profile:
+        source:
+          url: https://github.com/weaveworks/profiles-examples
+          tag: bitnami-nginx/v0.0.1
+    - name: nginx-deployment
+      kustomize:
+        path: nginx/deployment
+    - name: dokuwiki
+      chart:
+        url: https://charts.bitnami.com/bitnami
+        name: dokuwiki
+        version: "11.1.6"

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -365,7 +365,7 @@ spec:
   source:
     branch: local_clone_test
     path: weaveworks-nginx
-    profileURL: https://github.com/weaveworks/profiles-examples
+    url: https://github.com/weaveworks/profiles-examples
 status: {}
 `, namespace)))
 
@@ -699,12 +699,12 @@ status: {}
 
 			By("creating the artifacts")
 			Expect(files).To(ContainElements(
-				"profile-installation.yaml",
-				"artifacts/bitnami-nginx/HelmRelease.yaml",
-				"artifacts/bitnami-nginx/HelmRepository.yaml",
+				"nginx/profile-installation.yaml",
+				"nginx/artifacts/bitnami-nginx/HelmRelease.yaml",
+				"nginx/artifacts/bitnami-nginx/HelmRepository.yaml",
 			))
 
-			filename := filepath.Join(temp, "nginx", "profile-installation.yaml")
+			filename := filepath.Join(temp, "nginx", "nginx", "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1


### PR DESCRIPTION
### Description

https://github.com/weaveworks/pctl/issues/115

### In This PR

Shift the generation of the output into the artifact maker, lessening the dependencies of `Install`.

### Checklist
- [x] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
