### PR TITLE
pin go to 1.16

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
       - name: Cache go-build and mod
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
### Description

sometimes the workflow uses an older ubuntu image with go 1.15, causing:
```
# github.com/weaveworks/pctl/pkg/profile
pkg/profile/artifact.go:101:10: undefined: os.WriteFile
note: module requires Go 1.16
make: *** [Makefile:21: build] Error 2
```

https://github.com/weaveworks/pctl/runs/2885711173?check_suite_focus=true

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
