### PR TITLE
Add docgen command to create md help docs

### DIFF
--- a/cmd/pctl/docgen.go
+++ b/cmd/pctl/docgen.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func docgenCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "docgen",
+		Usage:     "generate the cli doc pages",
+		UsageText: "pctl docgen --out <relative-path-of-dir-to-write-docs>",
+		Hidden:    true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "path",
+				Usage: "The relative path to write the docs out. Default: pwd.",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			outPath := c.String("path")
+			if outPath != "" {
+				if _, err := os.Stat(outPath); os.IsNotExist(err) {
+					if err := os.MkdirAll(outPath, 0755); err != nil {
+						return err
+					}
+				}
+			}
+
+			for _, command := range c.App.Commands {
+				name := command.Name
+				if name == "help" || name == "docgen" {
+					continue
+				}
+
+				fileName := fmt.Sprintf("pctl-%s-cmd.md", name)
+				if err := writeCommandFile(c, name, outPath, fileName); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func writeCommandFile(c *cli.Context, command, outPath, fileName string) error {
+	f, err := os.Create(filepath.Join(outPath, fileName))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := writeHeader(f, command); err != nil {
+		return err
+	}
+
+	c.App.Writer = f
+	_ = cli.ShowCommandHelp(c, command)
+
+	return writeFooter(f)
+}
+
+func writeHeader(f *os.File, command string) error {
+	if _, err := f.WriteString(fmt.Sprintf("# %s\n\n```\n", command)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeFooter(f *os.File) error {
+	if _, err := f.WriteString("```"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/pctl/main.go
+++ b/cmd/pctl/main.go
@@ -28,6 +28,7 @@ func main() {
 			installCmd(),
 			listCmd(),
 			prepareCmd(),
+			docgenCmd(),
 		},
 	}
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -980,6 +980,73 @@ status: {}
 			})
 		})
 	})
+
+	Context("docgen", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = ioutil.TempDir("", "docgen")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_ = os.RemoveAll(tmpDir)
+		})
+
+		It("writes pctl command help to markdown files", func() {
+			cmd := exec.Command(binaryPath, "docgen", "--path", tmpDir)
+			_, err := cmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred())
+
+			files, err := ioutil.ReadDir(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(files)).To(Equal(5))
+			commands := []string{"install", "prepare", "list", "show", "search"}
+			for _, cmd := range commands {
+				filename := filepath.Join(tmpDir, fmt.Sprintf("pctl-%s-cmd.md", cmd))
+				Expect(filename).To(BeAnExistingFile())
+				contents, err := ioutil.ReadFile(filename)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(contents)).To(ContainSubstring(cmd))
+				Expect(string(contents)).To(ContainSubstring("NAME"))
+				Expect(string(contents)).To(ContainSubstring("USAGE"))
+			}
+		})
+
+		When("the provided output directory does not exist", func() {
+			It("creates it", func() {
+				newDir := filepath.Join(tmpDir, "does-not-exist")
+				Expect(newDir).ToNot(BeAnExistingFile())
+
+				cmd := exec.Command(binaryPath, "docgen", "--path", newDir)
+				_, err := cmd.CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(newDir).To(BeAnExistingFile())
+			})
+
+			When("creating the docs dir fails", func() {
+				It("exits 1", func() {
+					newDir := filepath.Join(tmpDir, "does-not-exist")
+					Expect(os.Chmod(tmpDir, 0600)).To(Succeed())
+
+					cmd := exec.Command(binaryPath, "docgen", "--path", newDir)
+					_, err := cmd.CombinedOutput()
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+
+		When("writing the docs files fails", func() {
+			It("exits 1", func() {
+				Expect(os.Chmod(tmpDir, 0600)).To(Succeed())
+
+				cmd := exec.Command(binaryPath, "docgen", "--path", tmpDir)
+				_, err := cmd.CombinedOutput()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })
 
 func randString(n int) (string, error) {


### PR DESCRIPTION
### Description

Adds command which will generate some handy markdown for our docs (same idea as what flux does):

```
$ pctl docgen --path docs/

$ ls docs
pctl-install-cmd.md  pctl-list-cmd.md  pctl-prepare-cmd.md  pctl-search-cmd.md  pctl-show-cmd.md
```

Connected to https://github.com/weaveworks/profiles/pull/228

I have added integration tests but really feel a lot of them should be units with the main actions extracted into a wee package. I am using the `cli` context/app/object thingy everywhere; has anyone found a good way to mock this in tests yet?

### Checklist
- [x] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
