### PR TITLE
Rename `--profile-url` to `--profile-repo-url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ with the following parameters:
 pctl add --name pctl-profile \
              --namespace default \
              --profile-branch devel \
-             --profile-url https://github.com/<usr>/<repo> \
+             --profile-repo-url https://github.com/<usr>/<repo> \
              --profile-path bitnami-nginx \
              --out <optional sub-folder inside the flux repository>
 ```
 
-It's the user's responsibility to make sure that the local `git` setup has access to the url provided with `profile-url`.
+It's the user's responsibility to make sure that the local `git` setup has access to the url provided with `profile-repo-url`.
 It can be any form of url as long as `git clone` understands it.
 
 
@@ -256,7 +256,7 @@ This looks as follows if installing via a URL:
 pctl add --name pctl-profile \
              --namespace [default] \
              --profile-branch [main] \
-             --profile-url git@github.com:org/private-profile-repo \
+             --profile-repo-url git@github.com:org/private-profile-repo \
              --profile-path <profile-name> \
              --git-repository <namespace>/<name> \
              --out <location of my flux repository>

--- a/cmd/pctl/add.go
+++ b/cmd/pctl/add.go
@@ -60,7 +60,7 @@ func addCmd() *cli.Command {
 		Aliases: []string{"apply"},
 		Usage:   "generate a profile installation",
 		UsageText: "To add from a profile catalog entry: pctl --catalog-url <URL> add --name pctl-profile --namespace default --profile-branch main --config-map configmap-name <CATALOG>/<PROFILE>[/<VERSION>]\n   " +
-			"To add directly from a profile repository: pctl add --name pctl-profile --namespace default --profile-branch development --profile-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx",
+			"To add directly from a profile repository: pctl add --name pctl-profile --namespace default --profile-branch development --profile-repo-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx",
 		Flags: append(createPRFlags,
 			&cli.StringFlag{
 				Name:        "name",
@@ -92,9 +92,9 @@ func addCmd() *cli.Command {
 				Usage:       "Optional location to create the profile installation folder in. This should be relative to the current working directory.",
 			},
 			&cli.StringFlag{
-				Name:  "profile-url",
+				Name:  "profile-repo-url",
 				Value: "",
-				Usage: "Optional value defining the URL of the profile.",
+				Usage: "Optional value defining the URL of the repository that contains the profile to be added.",
 			},
 			&cli.StringFlag{
 				Name:        "profile-path",
@@ -135,7 +135,7 @@ func addProfile(c *cli.Context) error {
 	)
 
 	// only set up the catalog if a url is not provided
-	url := c.String("profile-url")
+	url := c.String("profile-repo-url")
 	if url != "" && c.Args().Len() > 0 {
 		return errors.New("it looks like you provided a url with a catalog entry; please choose either format: url/branch/path or <CATALOG>/<PROFILE>[/<VERSION>]")
 	}

--- a/tests/integration/integration_add_test.go
+++ b/tests/integration/integration_add_test.go
@@ -121,7 +121,7 @@ var _ = Describe("pctl add", func() {
 				subName,
 				"--profile-branch",
 				profileBranch,
-				"--profile-url", profileExamplesURL,
+				"--profile-repo-url", profileExamplesURL,
 				"--profile-path", "weaveworks-nginx",
 				"--config-map", configMapName)
 			cmd.Dir = temp
@@ -365,7 +365,7 @@ status: {}
 					namespace+"/git-repo-name",
 					"--namespace",
 					namespace,
-					"--profile-url",
+					"--profile-repo-url",
 					profileExamplesURL,
 					"--profile-branch",
 					branch,
@@ -423,7 +423,7 @@ status: {}
 				namespace := uuid.New().String()
 				branch := "main"
 				path := "bitnami-nginx"
-				cmd := exec.Command(binaryPath, "add", "--out", temp, "--git-repository", namespace+"/git-repo-name", "--namespace", namespace, "--profile-url", pctlPrivateProfilesRepositoryName, "--profile-branch", branch, "--profile-path", path)
+				cmd := exec.Command(binaryPath, "add", "--out", temp, "--git-repository", namespace+"/git-repo-name", "--namespace", namespace, "--profile-repo-url", pctlPrivateProfilesRepositoryName, "--profile-branch", branch, "--profile-path", path)
 				cmd.Dir = temp
 
 				if v := os.Getenv("PRIVATE_EXAMPLES_DEPLOY_KEY"); v != "" {
@@ -481,7 +481,7 @@ status: {}
 					namespace+"/git-repo-name",
 					"--namespace",
 					namespace,
-					"--profile-url",
+					"--profile-repo-url",
 					profileExamplesURL,
 					"--profile-branch",
 					branch,


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

closes #246 
doc changes in https://github.com/weaveworks/profiles/pull/277

- Replacing `--profile-repo` with `--profile-repo-url` because it's better at conveying that it refers to the URL needed to clone the profile, not the full URL that leads to the profile.yaml itself.

### Checklist
- [ ] Added tests that cover your change
- [x] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
