### PR TITLE
add tagging to release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags: [ 'v*' ]
+  workflow_dispatch: {}
 
 env:
   IMAGE: pctl
@@ -33,12 +32,13 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          VERSION=sha-${GITHUB_SHA::8}
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF/refs\/tags\//}
-          fi
+          VERSION=v$(go run pkg/version/generate/release_generate.go full-version)
           echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=VERSION::${VERSION}
+      - name: Tag
+        run: |
+          git tag ${{ steps.prep.outputs.VERSION }}
+          git push origin ${{ steps.prep.outputs.VERSION }}
       - name: Publish multi-arch container image
         uses: docker/build-push-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -400,24 +400,18 @@ Steps:
    _Note: sometimes the release drafter is a bit of a pain, verify that the notes are
    correct by doing something like: `git log --first-parent tag1..tag2`._
 
-1. PR the release notes into main.
-_Note_ that you should also update the `var Version` in `pkg/version/release.go` file with the same tag which is created in the following step
-This should be automated with #233
+1. Update the `var Version` in `pkg/version/release.go` file to be the desired version.
 
-1. Create and push a tag with the new version:
-   ```sh
-   git tag <version>
-   git push origin <version>
-   ```
+1. PR the release notes and version bump into main.
 
-1. The `Create release` action should run. Verify that:
+1. Navigate to the `Actions` tab and manually trigger the `Release` job. When the job finishes verify that:
   1. The release has been created in Github
     1. With the correct assets
     1. With the correct release notes
   1. The image has been pushed to docker
   1. The image can be pulled and used in a deployment
 
-_Note_ that `<version>` must be in the following format: `v0.0.1`. 
+_Note_ that `<version>` must be in the following format: `v0.0.1`.
 
 ### Tests
 


### PR DESCRIPTION
### Description
Add the tagging to the release process. Now when releasing you just have to:
1. PR in the release notes and `version` change
1. trigger the action

 I tested that the tagging snippet worked on my fork https://github.com/aclevername/pctl/releases
 
 # Alternatives
 We can have the triggering of the release job happen automatically when a PR is merged with a particular label (like we do in eksctl with `trigger-release`, [example](https://github.com/weaveworks/eksctl/blob/244b190a31c2983221d090e5e9271526c23bbc9f/.github/workflows/tag-release.yaml#L15-L17)), but I find this to be a bit obscure. Manually triggering the job feels a bit cleaner

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
