### PR TITLE
escape multilines when passing release notes in workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,10 +70,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get release doc content
         id: vars
-        run: echo ::set-output name=release_notes::$(cat docs/release_notes/${{ steps.prep.outputs.VERSION }}.md)
+        run: |
+          echo 'release_notes<<EOF' >> $GITHUB_ENV
+          cat docs/release_notes/${{ steps.prep.outputs.VERSION }}.md >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Notify slack of new release
         uses: skarlso/slack-notification-action@28f5c1166e2fba7ed5a1d9ceaeb4f2c89a4e5bc5
         with:
           token: ${{ secrets.WEAVEWORKS_SLACK_PROFILESBOT_TOKEN }}
-          message: ":sparkles: A new release has been created for Pctl! :sparkles:\n\n${{ steps.vars.outputs.release_notes }}"
+          message: ":sparkles: A new release has been created for Pctl! :sparkles:\n\n${{ env.release_notes }}"
           channel: C01M9BYDE5U


### PR DESCRIPTION
### Description
The last time this run the slack message was all on one line, it should of been multilined. Fix from https://github.community/t/set-output-truncates-multiline-strings/16852/5


### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
