### PR TITLE
Change installation directory to default to profile installation name

### DIFF
--- a/cmd/pctl/add.go
+++ b/cmd/pctl/add.go
@@ -65,7 +65,6 @@ func addCmd() *cli.Command {
 		Flags: append(createPRFlags,
 			&cli.StringFlag{
 				Name:     "name",
-				Value:    "",
 				Usage:    "The name of the installation.",
 				Required: true,
 			},

--- a/cmd/pctl/add.go
+++ b/cmd/pctl/add.go
@@ -204,7 +204,7 @@ func addProfile(c *cli.Context) (string, error) {
 			gitRepoName = config.GitRepository.Name
 		}
 	}
-	installationDirectory := filepath.Join(dir, profileName)
+	installationDirectory := filepath.Join(dir, subName)
 	installer := install.NewInstaller(install.Config{
 		GitClient:        g,
 		RootDir:          installationDirectory,

--- a/cmd/pctl/add.go
+++ b/cmd/pctl/add.go
@@ -64,10 +64,10 @@ func addCmd() *cli.Command {
 			"To add directly from a profile repository: pctl add --name pctl-profile --namespace default --profile-branch development --profile-repo-url https://github.com/weaveworks/profiles-examples --profile-path bitnami-nginx",
 		Flags: append(createPRFlags,
 			&cli.StringFlag{
-				Name:        "name",
-				DefaultText: "pctl-profile",
-				Value:       "pctl-profile",
-				Usage:       "The name of the installation.",
+				Name:     "name",
+				Value:    "",
+				Usage:    "The name of the installation.",
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:        "namespace",

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -111,7 +111,7 @@ var _ = Describe("end to end flow", func() {
 			))
 
 			By("creating the artifacts")
-			profileDir := filepath.Join(temp, "weaveworks-nginx")
+			profileDir := filepath.Join(temp, profileInstallationName)
 			Expect(filesInDir(profileDir)).To(ContainElements(
 				"profile-installation.yaml",
 				"artifacts/nginx-deployment/kustomization.yaml",
@@ -198,7 +198,7 @@ status: {}
 				"Prerequisites Kubernetes 1.18+",
 			))
 
-			profileDir := filepath.Join(temp, "weaveworks-nginx")
+			profileDir := filepath.Join(temp, profileInstallationName)
 			cmd := exec.Command(
 				binaryPath,
 				"upgrade",

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -101,6 +101,7 @@ var _ = Describe("end to end flow", func() {
 		By("installing the desired profile", func() {
 			pctlAddOutput := pctl(
 				"add",
+				"--name", profileInstallationName,
 				"--namespace", namespace,
 				"--config-map", configMapName,
 				"nginx-catalog/weaveworks-nginx/v0.1.0",

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -165,7 +165,7 @@ status: {}
 			output, err := cmd.CombinedOutput()
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("flux reconcile source git failed : %s", string(output)))
 
-			cmd = exec.Command("flux", "create", "kustomization", "kustomization", "--path", "weaveworks-nginx/", "--source", fmt.Sprintf("GitRepository/%s", gitRepoName), "--namespace", namespace)
+			cmd = exec.Command("flux", "create", "kustomization", "kustomization", "--path", profileInstallationName+"/", "--source", fmt.Sprintf("GitRepository/%s", gitRepoName), "--namespace", namespace)
 			output, err = cmd.CombinedOutput()
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("flux create kustomization failed : %s", string(output)))
 

--- a/tests/integration/integration_add_test.go
+++ b/tests/integration/integration_add_test.go
@@ -80,6 +80,7 @@ var _ = Describe("pctl add", func() {
 
 		args := []string{
 			"add",
+			"--name", subName,
 			"--git-repository",
 			fmt.Sprintf("%s/%s", namespace, gitRepoName),
 			"--namespace", namespace,
@@ -309,6 +310,7 @@ status: {}
 			path := "bitnami-nginx"
 			args := []string{
 				"add",
+				"--name", "pctl-profile",
 				"--git-repository",
 				namespace + "/git-repo-name",
 				"--namespace",
@@ -358,7 +360,7 @@ status: {}
 			namespace := uuid.New().String()
 			branch := "main"
 			path := "bitnami-nginx"
-			cmd := exec.Command(binaryPath, "add", "--out", temp, "--git-repository", namespace+"/git-repo-name", "--namespace", namespace, "--profile-repo-url", pctlPrivateProfilesRepositoryName, "--profile-branch", branch, "--profile-path", path)
+			cmd := exec.Command(binaryPath, "add", "--name", "pctl-profile", "--out", temp, "--git-repository", namespace+"/git-repo-name", "--namespace", namespace, "--profile-repo-url", pctlPrivateProfilesRepositoryName, "--profile-branch", branch, "--profile-path", path)
 			cmd.Dir = temp
 
 			if v := os.Getenv("PRIVATE_EXAMPLES_DEPLOY_KEY"); v != "" {
@@ -398,12 +400,12 @@ status: {}
 	When("url and catalog entry add format are both defined", func() {
 		It("will throw a meaningful error", func() {
 			namespace := uuid.New().String()
-			//subName := "pctl-profile"
 			branch := "branch-and-url"
 			path := "branch-nginx"
 			cmd := exec.Command(
 				binaryPath,
 				"add",
+				"--name", "pctl-profile",
 				"--git-repository",
 				namespace+"/git-repo-name",
 				"--namespace",
@@ -425,7 +427,7 @@ status: {}
 
 	When("a catalog version is provided, but it's an invalid/missing version", func() {
 		It("provide an error saying the profile with these specifics can't be found", func() {
-			cmd := exec.Command(binaryPath, "add", "--git-repository", namespace+"/git-repo-name", "nginx-catalog/weaveworks-nginx/v999.9.9")
+			cmd := exec.Command(binaryPath, "add", "--name", "pctl-profile", "--git-repository", namespace+"/git-repo-name", "nginx-catalog/weaveworks-nginx/v999.9.9")
 			output, err := cmd.CombinedOutput()
 			Expect(err).To(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring(`unable to find profile "weaveworks-nginx" in catalog "nginx-catalog" (with version if provided: v999.9.9)`))
@@ -451,6 +453,7 @@ status: {}
 			branch := "prtest_" + suffix
 			cmd = exec.Command(binaryPath,
 				"add",
+				"--name", "pctl-profile",
 				"--git-repository", namespace+"/git-repo-name",
 				"--create-pr",
 				"--pr-branch",
@@ -473,6 +476,7 @@ status: {}
 			cmd := exec.Command(
 				binaryPath,
 				"add",
+				"--name", "pctl-profile",
 				"--git-repository", namespace+"/git-repo-name",
 				"--create-pr",
 				"--pr-branch",
@@ -492,6 +496,7 @@ status: {}
 			cmd := exec.Command(
 				binaryPath,
 				"add",
+				"--name", "pctl-profile",
 				"--git-repository", namespace+"/git-repo-name",
 				"--create-pr",
 				"--pr-branch",

--- a/tests/integration/integration_add_test.go
+++ b/tests/integration/integration_add_test.go
@@ -95,7 +95,7 @@ var _ = Describe("pctl add", func() {
 			fmt.Sprintf("► generating profile installation from source: repository %s, path: %s and branch %s", profileExamplesURL, "weaveworks-nginx", profileBranch),
 		))
 
-		profilesDir := filepath.Join(temp)
+		profilesDir := filepath.Join(temp, subName)
 		By("creating the artifacts")
 		Expect(filesInDir(profilesDir)).To(ContainElements(
 			"profile-installation.yaml",
@@ -117,7 +117,7 @@ var _ = Describe("pctl add", func() {
 			"artifacts/nested-profile/nginx-server/kustomize-flux.yaml",
 		))
 
-		Expect(catFile(filepath.Join(temp, "profile-installation.yaml"))).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
+		Expect(catFile(filepath.Join(profilesDir, "profile-installation.yaml"))).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
 kind: ProfileInstallation
 metadata:
   creationTimestamp: null
@@ -323,10 +323,10 @@ status: {}
 			Expect(pctl(args...)).To(ContainElement("✔ installation completed successfully"))
 			By("creating the artifacts")
 			Expect(filesInDir(temp)).To(ContainElements(
-				"profile-installation.yaml",
-				filepath.Join("artifacts", "nginx-server", "helm-chart", "HelmRelease.yaml"),
-				filepath.Join("artifacts", "nginx-server", "helm-chart", "kustomization.yaml"),
-				filepath.Join("artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
+				"pctl-profile/profile-installation.yaml",
+				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "HelmRelease.yaml"),
+				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "kustomization.yaml"),
+				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
 			))
 			filename := filepath.Join(temp, "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
@@ -370,8 +370,8 @@ status: {}
 
 			By("creating the artifacts")
 			Expect(filesInDir(temp)).To(ContainElements(
-				"profile-installation.yaml",
-				filepath.Join("artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
+				"pctl-profile/profile-installation.yaml",
+				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
 			))
 			filename := filepath.Join(temp, "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
@@ -550,6 +550,7 @@ status: {}
 			By("adding the profile")
 			args := []string{
 				"add",
+				"--name", subName,
 				"--namespace", namespace,
 				"--git-repository", fmt.Sprintf("%s/%s", namespace, gitRepoName),
 				"nginx-catalog/nginx/v2.0.1",
@@ -557,7 +558,7 @@ status: {}
 			Expect(pctl(args...)).To(ContainElement("► generating profile installation from source: catalog entry nginx-catalog/nginx/v2.0.1"))
 
 			By("creating the artifacts")
-			profilesDir := filepath.Join(temp, "nginx")
+			profilesDir := filepath.Join(temp, subName)
 			Expect(filesInDir(profilesDir)).To(ContainElements(
 				"artifacts/bitnami-nginx/helm-chart/ConfigMap.yaml",
 				"artifacts/bitnami-nginx/helm-chart/HelmRelease.yaml",

--- a/tests/integration/integration_add_test.go
+++ b/tests/integration/integration_add_test.go
@@ -328,7 +328,7 @@ status: {}
 				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "kustomization.yaml"),
 				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
 			))
-			filename := filepath.Join(temp, "profile-installation.yaml")
+			filename := filepath.Join(temp, "pctl-profile", "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1
@@ -373,7 +373,7 @@ status: {}
 				"pctl-profile/profile-installation.yaml",
 				filepath.Join("pctl-profile", "artifacts", "nginx-server", "helm-chart", "nginx", "chart", "Chart.yaml"),
 			))
-			filename := filepath.Join(temp, "profile-installation.yaml")
+			filename := filepath.Join(temp, "pctl-profile", "profile-installation.yaml")
 			content, err := ioutil.ReadFile(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(content)).To(Equal(fmt.Sprintf(`apiVersion: weave.works/v1alpha1

--- a/tests/integration/integration_update_test.go
+++ b/tests/integration/integration_update_test.go
@@ -47,8 +47,10 @@ var _ = Describe("update", func() {
 		It("informs the user of where the conflicts are", func() {
 			By("installing a profile")
 			gitRepoName := "my-git-repo"
+			subname := "pctl-profile"
 			args := []string{
 				"add",
+				"--name", subname,
 				"--git-repository",
 				fmt.Sprintf("%s/%s", namespace, gitRepoName),
 				"--namespace", namespace,
@@ -61,7 +63,7 @@ var _ = Describe("update", func() {
 				"✔ installation completed successfully",
 			))
 
-			profileDir := filepath.Join(temp, "pctl-profile")
+			profileDir := filepath.Join(temp, subname)
 			By("creating the artifacts")
 			Expect(filesInDir(profileDir)).To(ContainElements(
 				"profile-installation.yaml",

--- a/tests/integration/integration_update_test.go
+++ b/tests/integration/integration_update_test.go
@@ -61,7 +61,7 @@ var _ = Describe("update", func() {
 				"✔ installation completed successfully",
 			))
 
-			profileDir := filepath.Join(temp, "weaveworks-nginx")
+			profileDir := filepath.Join(temp, "pctl-profile")
 			By("creating the artifacts")
 			Expect(filesInDir(profileDir)).To(ContainElements(
 				"profile-installation.yaml",


### PR DESCRIPTION
### Description
Running `pctl add --name jake-rocks nginx-catalog/weaveworks-nginx/v0.1.1` now creates a `jake-rocks` directory instead of `weaveworks-nginx` directory. 

Closes #289 

### Checklist
- [x] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
