### PR TITLE
Fix pctl get error messages

### DIFF
--- a/cmd/pctl/get.go
+++ b/cmd/pctl/get.go
@@ -200,7 +200,7 @@ func profileWithVersionDataFunc(profile profilesv1.ProfileCatalogEntry) func() i
 
 func formatOutput(profiles []profilesv1.ProfileCatalogEntry, outFormat string) error {
 	if len(profiles) == 0 {
-		log.Failuref("No profiles found")
+		log.Failuref("No available catalog profiles found.")
 		return nil
 	}
 
@@ -228,7 +228,7 @@ func formatOutput(profiles []profilesv1.ProfileCatalogEntry, outFormat string) e
 
 func formatInstalledProfilesOutput(data []catalog.ProfileData, outFormat string) error {
 	if len(data) == 0 {
-		log.Failuref("no profiles installed")
+		log.Failuref("No installed profiles found.")
 		return nil
 	}
 
@@ -256,7 +256,7 @@ func formatInstalledProfilesOutput(data []catalog.ProfileData, outFormat string)
 
 func formatCatlogProfilesOutput(profile profilesv1.ProfileCatalogEntry, outFormat string) error {
 	if profile.Name == "" {
-		log.Failuref("no profile found")
+		log.Failuref("No profile found.")
 		return nil
 	}
 


### PR DESCRIPTION
### Description
Cleaned up the error messages for `pctl get` command to make it consistent and less confusing. Closes #294 

When no installed profiles are found 
``` ✗ No installed profiles found. ``` 

When no catalog profiles are found 
``` ✗ No available catalog profiles found. ``` 

When no profile with the `--profile-version` is found 
``` ✗ No profile found. ``` 

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [x] Added a `kind` label to the PR (e.g. `kind/feature`)
