### PR TITLE
error when user tries to upgrade a non-catalog installation

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -48,6 +48,10 @@ func Upgrade(cfg Config) error {
 		return fmt.Errorf("failed to parse profile installation: %w", err)
 	}
 
+	if profileInstallation.Spec.Catalog == nil {
+		return fmt.Errorf("unable to upgrade an installation that was not created from a catalog")
+	}
+
 	var gitRepoName, gitRepoNamespace string
 	catalogName := profileInstallation.Spec.Catalog.Catalog
 	profileName := profileInstallation.Spec.Catalog.Profile


### PR DESCRIPTION
### Description

We need the `profileinstallation.yaml` to have a `spec.catalog` entry to do upgrades. When a user installs a profile via a URL this field isn't set, meaning we can't upgrade the profile. This PR fixes it so that we return a meaningful error.

Before:
```
$ pctl add --name jake-rocks --profile-repo-url https://github.com/weaveworks/nginx-profile --profile-path . --git-repository foo/bar
... success
$ pctl upgrade .wego/profiles/jake-rocks --latest
 panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x18ae041]

goroutine 1 [running]:
github.com/weaveworks/pctl/pkg/upgrade.Upgrade(0x7fff3cccb33a, 0x19, 0x7fff3cccb354, 0x8, 0x1f4ae60, 0xc0005a9130, 0x1f82b80, 0x2be4c40, 0x1f747b0, 0xc0000f0d80, ...)
        github.com/weaveworks/pctl/pkg/upgrade/upgrade.go:52 +0x2a1
main.upgrade(0xc0005a6680, 0x0, 0x0)
        github.com/weaveworks/pctl/cmd/pctl/upgrade.go:91 +0x618
main.upgradeCmd.func1(0xc0005a6680, 0x8, 0xc)
        github.com/weaveworks/pctl/cmd/pctl/upgrade.go:29 +0x2f
github.com/urfave/cli/v2.(*Command).Run(0xc00044de60, 0xc0005a63c0, 0x0, 0x0)
        github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4dd
github.com/urfave/cli/v2.(*App).RunContext(0xc00039ad00, 0x1f82790, 0xc000044140, 0xc00003a080, 0x4, 0x4, 0x0, 0x0)
        github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
        github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
        github.com/weaveworks/pctl/cmd/pctl/main.go:38 +0x225
```

After:
```
$ pctl add --name jake-rocks --profile-repo-url https://github.com/weaveworks/nginx-profile --profile-path . --git-repository foo/bar
... success
$ pctl upgrade .wego/profiles/jake-rocks --latest
✗ unable to upgrade an installation that was not created from a catalog 
```

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
