### PR TITLE
Set default helm release interval to 5m

### DIFF
--- a/pkg/install/artifact/artifact.go
+++ b/pkg/install/artifact/artifact.go
@@ -29,6 +29,7 @@ const (
 	defaultValuesKey           = "default-values.yaml"
 	helmChartLocation          = "helm-chart"
 	kustomizeWrapperObjectName = "kustomize-flux.yaml"
+	defaultInterval            = time.Minute * 5
 )
 
 // ArtifactWriter can build an artifacts from an installation and a profile artifact.
@@ -255,6 +256,7 @@ func (c *Writer) makeHelmReleaseObjects(artifact profilesv1.Artifact, installati
 			APIVersion: helmv2.GroupVersion.String(),
 		},
 		Spec: helmv2.HelmReleaseSpec{
+			Interval:    metav1.Duration{Duration: defaultInterval},
 			ReleaseName: artifact.Name,
 			Chart: helmv2.HelmChartTemplate{
 				Spec: helmChartSpec,

--- a/pkg/install/artifact/artifact_chart_test.go
+++ b/pkg/install/artifact/artifact_chart_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
@@ -144,6 +145,7 @@ var _ = Describe("Helm", func() {
 			},
 			Spec: helmv2.HelmReleaseSpec{
 				ReleaseName: artifactName,
+				Interval:    metav1.Duration{Duration: time.Minute * 5},
 				Chart: helmv2.HelmChartTemplate{
 					Spec: helmv2.HelmChartTemplateSpec{
 						Chart: filepath.Join(rootDir, "artifacts/1/helm-chart/files/"),
@@ -259,6 +261,7 @@ var _ = Describe("Helm", func() {
 					Namespace: namespace,
 				},
 				Spec: helmv2.HelmReleaseSpec{
+					Interval:    metav1.Duration{Duration: time.Minute * 5},
 					ReleaseName: artifactName,
 					Chart: helmv2.HelmChartTemplate{
 						Spec: helmv2.HelmChartTemplateSpec{


### PR DESCRIPTION
### Description

Closes https://github.com/weaveworks/profiles/issues/327

Value set to 5m as discussed in the above issue

### Checklist
- [ ] Added tests that cover your change
- [ ] Added/modified documentation as required (such as the `README.md`)
- [ ] Made sure the title of the PR is a good description that can go into the release notes
- [ ] Added a `kind` label to the PR (e.g. `kind/feature`)
